### PR TITLE
Convenience constructor (static methods really)

### DIFF
--- a/lib/src/extensions/benefits.dart
+++ b/lib/src/extensions/benefits.dart
@@ -4,6 +4,13 @@ import 'package:moment_dart/src/extensions/constructor.dart';
 export 'duration.dart';
 
 extension MomentBenefits on DateTime {
+  bool get isFuture => isFutureAnchored();
+  bool get isPast => isPastAnchored();
+
+  bool isFutureAnchored([DateTime? anchor]) =>
+      isAfter(anchor ?? DateTime.now());
+  bool isPastAnchored([DateTime? anchor]) => isBefore(anchor ?? DateTime.now());
+
   /// Returns if [year] is leap year.
   ///
   /// More about leap years: [Leap Year](https://en.wikipedia.org/wiki/Leap_year)

--- a/lib/src/moment.dart
+++ b/lib/src/moment.dart
@@ -448,4 +448,107 @@ class Moment extends DateTime {
         (seperateWithColon ? ":" : "") +
         minutes.toString();
   }
+
+  /// Start of today in a local timezone
+  static DateTime startOfToday() => DateTime.now().startOfDay();
+
+  /// Start of tomorrow in a local timezone
+  static DateTime startOfTomorrow() {
+    final DateTime now = DateTime.now();
+
+    return DateTime(now.year, now.month, now.day + 1);
+  }
+
+  /// Start of yesterday in a local timezone
+  static DateTime startOfYesterday() {
+    final DateTime now = DateTime.now();
+
+    return DateTime(now.year, now.month, now.day - 1);
+  }
+
+  /// Start of the current month in a local timezone
+  static DateTime startOfThisMonth() => DateTime.now().startOfMonth();
+
+  /// Start of the next month in a local timezone
+  static DateTime startOfNextMonth() {
+    final DateTime now = DateTime.now();
+
+    return DateTime(now.year, now.month + 1);
+  }
+
+  /// Start of the previous month in a local timezone
+  static DateTime startOfPrevMonth() {
+    final DateTime now = DateTime.now();
+
+    return DateTime(now.year, now.month - 1);
+  }
+
+  static DateTime startOfThisYear() => DateTime.now().startOfYear();
+
+  static DateTime startOfNextYear() {
+    final DateTime now = DateTime.now();
+
+    return DateTime(now.year + 1);
+  }
+
+  static DateTime startOfLastYear() {
+    final DateTime now = DateTime.now();
+
+    return DateTime(now.year - 1);
+  }
+
+  /// End of today in a local timezone
+  static DateTime endOfToday() => DateTime.now().endOfDay();
+
+  /// End of tomorrow in a local timezone
+  static DateTime endOfTomorrow() {
+    final DateTime now = DateTime.now();
+
+    return DateTime(now.year, now.month, now.day + 1, 23, 59, 59, 999, 999);
+  }
+
+  /// End of yesterday in a local timezone
+  static DateTime endOfYesterday() {
+    final DateTime now = DateTime.now();
+
+    return DateTime(now.year, now.month, now.day - 1, 23, 59, 59, 999, 999);
+  }
+
+  /// End of the current month in a local timezone
+  static DateTime endOfThisMonth() => DateTime.now().endOfMonth();
+
+  /// End of the next month in a local timezone
+  static DateTime endOfNextMonth() {
+    final DateTime now = DateTime.now();
+
+    return DateTime(now.year, now.month + 1).endOfMonth();
+  }
+
+  /// End of the previous month in a local timezone
+  static DateTime endOfPrevMonth() {
+    final DateTime now = DateTime.now();
+
+    return DateTime(now.year, now.month - 1).endOfMonth();
+  }
+
+  static DateTime endOfThisYear() => DateTime.now().endOfYear();
+
+  static DateTime endOfNextYear() {
+    final DateTime now = DateTime.now();
+
+    return DateTime(now.year + 1, 12, 31, 23, 59, 59, 999, 999);
+  }
+
+  static DateTime endOfLastYear() {
+    final DateTime now = DateTime.now();
+
+    return DateTime(now.year - 1, 12, 31, 23, 59, 59, 999, 999);
+  }
+
+  /// epoch, but in local timezone
+  static DateTime epoch = DateTime.fromMicrosecondsSinceEpoch(0);
+
+  /// epoch in UTC
+  static DateTime epochUtc =
+      DateTime.fromMicrosecondsSinceEpoch(0, isUtc: true);
 }

--- a/test/general_test.dart
+++ b/test/general_test.dart
@@ -438,4 +438,59 @@ void main() {
 
     expect(q1, "YEAR: 1971, MONTH: February, 14th Sunday AM ][12:00");
   });
+
+  group("start/end of X static methods", () {
+    final now = DateTime.now();
+
+    test("start of", () {
+      expect(Moment.startOfToday(), DateTime(now.year, now.month, now.day));
+      expect(
+          Moment.startOfTomorrow(), DateTime(now.year, now.month, now.day + 1));
+      expect(Moment.startOfYesterday(),
+          DateTime(now.year, now.month, now.day - 1));
+      expect(Moment.startOfThisMonth(), DateTime(now.year, now.month));
+      expect(Moment.startOfNextMonth(), DateTime(now.year, now.month + 1));
+      expect(Moment.startOfPrevMonth(), DateTime(now.year, now.month - 1));
+      expect(Moment.startOfThisYear(), DateTime(now.year));
+      expect(Moment.startOfNextYear(), DateTime(now.year + 1));
+      expect(Moment.startOfLastYear(), DateTime(now.year - 1));
+    });
+
+    test("end of", () {
+      expect(Moment.endOfToday(),
+          DateTime(now.year, now.month, now.day).endOfDay());
+      expect(Moment.endOfTomorrow(),
+          DateTime(now.year, now.month, now.day + 1).endOfDay());
+      expect(Moment.endOfYesterday(),
+          DateTime(now.year, now.month, now.day - 1).endOfDay());
+      expect(
+          Moment.endOfThisMonth(), DateTime(now.year, now.month).endOfMonth());
+      expect(Moment.endOfNextMonth(),
+          DateTime(now.year, now.month + 1).endOfMonth());
+      expect(Moment.endOfPrevMonth(),
+          DateTime(now.year, now.month - 1).endOfMonth());
+      expect(Moment.endOfThisYear(), DateTime(now.year).endOfYear());
+      expect(Moment.endOfNextYear(), DateTime(now.year + 1).endOfYear());
+      expect(Moment.endOfLastYear(), DateTime(now.year - 1).endOfYear());
+    });
+  });
+
+  test("epoch static methods", () {
+    expect(Moment.epoch, DateTime.fromMicrosecondsSinceEpoch(0));
+    expect(
+        Moment.epochUtc, DateTime.fromMicrosecondsSinceEpoch(0, isUtc: true));
+  });
+
+  test("isFuture / isPast", () {
+    final now = DateTime.now();
+    final epoch = Moment.epoch;
+    final tt = DateTime(3000);
+
+    expect(now.add(Duration(days: 1)).isFuture, true);
+    expect(now.subtract(Duration(days: 1)).isPast, true);
+    expect(now.isFutureAnchored(epoch), true);
+    expect(now.isFutureAnchored(tt), false);
+    expect(now.isPastAnchored(epoch), false);
+    expect(now.isPastAnchored(tt), true);
+  });
 }


### PR DESCRIPTION
Adds following static methods and properties for `Moment`, alongside with the tests.

* Moment.startOfToday()
* Moment.startOfTomorrow()
* Moment.startOfYesterday()
* Moment.startOfThisMonth()
* Moment.startOfNextMonth()
* Moment.startOfPrevMonth()
* Moment.startOfThisYear()
* Moment.startOfNextYear()
* Moment.startOfLastYear()
* Moment.endOfToday()
* Moment.endOfTomorrow()
* Moment.endOfYesterday()
* Moment.endOfThisMonth()
* Moment.endOfNextMonth()
* Moment.endOfPrevMonth()
* Moment.endOfThisYear()
* Moment.endOfNextYear()
* Moment.endOfLastYear()
* Moment.epoch
* Moment.epochUtc