### PR TITLE
Release v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 2.0.0
+
+- TimeRange
+  - **[BREAKING]** Renamed all variable/methods with "prev" to "last"
+  - Added `HourTimeRange`, `LocalWeekTimeRange` and `IsoWeekTimeRange`
+  - **[BREAKING]** TimeRange's `to` is now exclusive. This means
+    `DayTimeRange().duration` will equal to `Duration(days:1)` unless there's a
+    [daylight saving](https://en.wikipedia.org/wiki/Daylight_saving_time#Effects_on_social_relations)
+     going on.
+  - Added next/last getters on some TimeRange classes.
+- **[BREAKING]** Removes deprecated formatter tokens `YYYYYY` and `Y`
+- `Moment.` relative constructors
+  - **[BREAKING]** Renamed all variable/methods with "prev" to "last"
+  - Added `Moment.startOfThisLocalWeek()`, with `endOf` and `next`/`prev` variants
+  - Added `Moment.startOfThisIsoWeek()`, with `endOf` and `next`/`prev` variants
+  - Added `Moment.startOfThisHour()`, with `endOf` and `next`/`prev` variants
+- Added relative finder methods such as `.startOfNextDay()`.
+- Added `.startOfIsoWeek()` and `.endOfIsoWeek()`
+- Exposes `DateTimeConstructors` (no longer need to import)
+
 ## 1.2.0
 
 - Added getter/method to check if `DateTime` is in the past or future

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -9,3 +9,7 @@ export 'package:moment_dart/src/extensions/end_of.dart';
 export 'package:moment_dart/src/extensions/unit_comparison.dart';
 
 export 'package:moment_dart/src/extensions/weekday_finder.dart';
+
+export 'package:moment_dart/src/extensions/relative_finder.dart';
+
+export 'package:moment_dart/src/extensions/constructor.dart';

--- a/lib/src/extensions/benefits.dart
+++ b/lib/src/extensions/benefits.dart
@@ -1,5 +1,4 @@
 import 'package:moment_dart/moment_dart.dart';
-import 'package:moment_dart/src/extensions/constructor.dart';
 
 export 'duration.dart';
 
@@ -217,6 +216,15 @@ extension MomentBenefits on DateTime {
     }
 
     return toMoment(localization: localization).format(payload, forceLocal);
+  }
+
+  /// Returns [CustomTimeRange] from [this] to [other]
+  ///
+  /// If [this] is after [other], it will be swapped.
+  CustomTimeRange to(DateTime other) {
+    if (this <= other) return CustomTimeRange(this, other);
+
+    return CustomTimeRange(other, this);
   }
 }
 

--- a/lib/src/extensions/end_of.dart
+++ b/lib/src/extensions/end_of.dart
@@ -1,5 +1,4 @@
 import 'package:moment_dart/src/exception.dart';
-import 'package:moment_dart/src/extensions/constructor.dart';
 import 'package:moment_dart/src/moment.dart';
 
 extension EndOfUnit on DateTime {
@@ -159,6 +158,11 @@ extension EndOfUnit on DateTime {
     return add(Duration(days: delta)).endOfDay();
   }
 
+  /// Returns end of the ISO week (always Sunday)
+  ///
+  /// Returned object will have same timezone as [this]
+  DateTime endOfIsoWeek() => endOfLocalWeek(DateTime.monday);
+
   /// Returns end of the month
   ///
   /// Returned object will have same timezone as [this]
@@ -224,6 +228,11 @@ extension EndOfUnitMoment on Moment {
         .endOfLocalWeek(weekStart ?? localization.weekStart)
         .toMoment(localization: setLocalization);
   }
+
+  /// Returns start of the ISO week (always Monday)
+  ///
+  /// Returned object will have same timezone as [this]
+  Moment endOfIsoWeek() => endOfLocalWeek(DateTime.monday);
 
   /// Returns end of the month
   ///

--- a/lib/src/extensions/relative_finder.dart
+++ b/lib/src/extensions/relative_finder.dart
@@ -1,0 +1,279 @@
+import 'package:moment_dart/moment_dart.dart';
+
+extension YearFinder on DateTime {
+  /// Returns a new [DateTime] of same timezone
+  DateTime startOfNextYear() =>
+      DateTimeConstructors.withTimezone(isUtc, year + 1);
+
+  /// Returns a new [DateTime] of same timezone
+  DateTime startOfLastYear() =>
+      DateTimeConstructors.withTimezone(isUtc, year - 1);
+
+  /// Returns a new [DateTime] of same timezone
+  DateTime endOfNextYear() =>
+      DateTimeConstructors.withTimezone(isUtc, year + 1).endOfYear();
+
+  /// Returns a new [DateTime] of same timezone
+  DateTime endOfLastYear() =>
+      DateTimeConstructors.withTimezone(isUtc, year - 1).endOfYear();
+}
+
+extension MonthFinder on DateTime {
+  /// Returns a new [DateTime] of same timezone
+  DateTime startOfNextMonth() =>
+      DateTimeConstructors.withTimezone(isUtc, year, month + 1);
+
+  /// Returns a new [DateTime] of same timezone
+  DateTime startOfLastMonth() =>
+      DateTimeConstructors.withTimezone(isUtc, year, month - 1);
+
+  /// Returns a new [DateTime] of same timezone
+  DateTime endOfNextMonth() =>
+      DateTimeConstructors.withTimezone(isUtc, year, month + 1).endOfMonth();
+
+  /// Returns a new [DateTime] of same timezone
+  DateTime endOfLastMonth() =>
+      DateTimeConstructors.withTimezone(isUtc, year, month - 1).endOfMonth();
+}
+
+extension LocalWeekFinder on DateTime {
+  /// Assumes [this] is in local timezone, but will preserve the timezone
+  DateTime startOfNextLocalWeek([int? weekStart]) =>
+      startOfLocalWeek(weekStart).add(const Duration(days: 7));
+
+  /// Assumes [this] is in local timezone, but will preserve the timezone
+  DateTime startOfLastLocalWeek([int? weekStart]) =>
+      startOfLocalWeek(weekStart).subtract(const Duration(days: 7));
+
+  /// Assumes [this] is in local timezone, but will preserve the timezone
+  DateTime endOfNextLocalWeek([int? weekStart]) =>
+      endOfLocalWeek(weekStart).add(const Duration(days: 7));
+
+  /// Assumes [this] is in local timezone, but will preserve the timezone
+  DateTime endOfLastLocalWeek([int? weekStart]) =>
+      endOfLocalWeek(weekStart).subtract(const Duration(days: 7));
+}
+
+extension IsoWeekFinder on DateTime {
+  /// Assumes [this] is in local timezone, but will preserve the timezone
+  DateTime startOfNextIsoWeek() => startOfNextLocalWeek(DateTime.monday);
+
+  /// Assumes [this] is in local timezone, but will preserve the timezone
+  DateTime startOfLastIsoWeek() => startOfLastLocalWeek(DateTime.monday);
+
+  /// Assumes [this] is in local timezone, but will preserve the timezone
+  DateTime endOfNextIsoWeek() => endOfNextLocalWeek(DateTime.monday);
+
+  /// Assumes [this] is in local timezone, but will preserve the timezone
+  DateTime endOfLastIsoWeek() => endOfLastLocalWeek(DateTime.monday);
+}
+
+extension DayFinder on DateTime {
+  /// Returns a new [DateTime] of same timezone
+  DateTime startOfNextDay() =>
+      DateTimeConstructors.withTimezone(isUtc, year, month, day + 1);
+
+  /// Returns a new [DateTime] of same timezone
+  DateTime startOfLastDay() =>
+      DateTimeConstructors.withTimezone(isUtc, year, month, day - 1);
+
+  /// Returns a new [DateTime] of same timezone
+  DateTime endOfNextDay() =>
+      DateTimeConstructors.withTimezone(isUtc, year, month, day + 1).endOfDay();
+
+  /// Returns a new [DateTime] of same timezone
+  DateTime endOfLastDay() =>
+      DateTimeConstructors.withTimezone(isUtc, year, month, day - 1).endOfDay();
+}
+
+extension HourFinder on DateTime {
+  /// Returns a new [DateTime] of same timezone
+  DateTime startOfNextHour() =>
+      DateTimeConstructors.withTimezone(isUtc, year, month, day, hour + 1);
+
+  /// Returns a new [DateTime] of same timezone
+  DateTime startOfLastHour() =>
+      DateTimeConstructors.withTimezone(isUtc, year, month, day, hour - 1);
+
+  /// Returns a new [DateTime] of same timezone
+  DateTime endOfNextHour() => DateTimeConstructors.withTimezone(
+        isUtc,
+        year,
+        month,
+        day,
+        hour + 1,
+        59,
+        59,
+        999,
+        999,
+      );
+
+  /// Returns a new [DateTime] of same timezone
+  DateTime endOfLastHour() => DateTimeConstructors.withTimezone(
+        isUtc,
+        year,
+        month,
+        day,
+        hour - 1,
+        59,
+        59,
+        999,
+        999,
+      );
+}
+
+extension MinuteFinder on DateTime {
+  /// Returns a new [DateTime] of same timezone
+  DateTime startOfNextMinute() => DateTimeConstructors.withTimezone(
+      isUtc, year, month, day, hour, minute + 1);
+
+  /// Returns a new [DateTime] of same timezone
+  DateTime startOfLastMinute() => DateTimeConstructors.withTimezone(
+      isUtc, year, month, day, hour, minute - 1);
+
+  /// Returns a new [DateTime] of same timezone
+  DateTime endOfNextMinute() => DateTimeConstructors.withTimezone(
+      isUtc, year, month, day, hour, minute + 1, 59, 999, 999);
+
+  /// Returns a new [DateTime] of same timezone
+  DateTime endOfLastMinute() => DateTimeConstructors.withTimezone(
+      isUtc, year, month, day, hour, minute - 1, 59, 999, 999);
+}
+
+extension YearFinderMoment on Moment {
+  /// Returns a new [Moment] of same timezone
+  Moment startOfNextYear() =>
+      forcedSuperType.startOfNextYear().toMoment(localization: setLocalization);
+
+  /// Returns a new [Moment] of same timezone
+  Moment startOfLastYear() =>
+      forcedSuperType.startOfLastYear().toMoment(localization: setLocalization);
+
+  /// Returns a new [Moment] of same timezone
+  Moment endOfNextYear() =>
+      forcedSuperType.endOfNextYear().toMoment(localization: setLocalization);
+
+  /// Returns a new [Moment] of same timezone
+  Moment endOfLastYear() =>
+      forcedSuperType.endOfLastYear().toMoment(localization: setLocalization);
+}
+
+extension MonthFinderMoment on Moment {
+  /// Returns a new [Moment] of same timezone
+  Moment startOfNextMonth() => forcedSuperType
+      .startOfNextMonth()
+      .toMoment(localization: setLocalization);
+
+  /// Returns a new [Moment] of same timezone
+  Moment startOfLastMonth() => forcedSuperType
+      .startOfLastMonth()
+      .toMoment(localization: setLocalization);
+
+  /// Returns a new [Moment] of same timezone
+  Moment endOfNextMonth() =>
+      forcedSuperType.endOfNextMonth().toMoment(localization: setLocalization);
+
+  /// Returns a new [Moment] of same timezone
+  Moment endOfLastMonth() =>
+      forcedSuperType.endOfLastMonth().toMoment(localization: setLocalization);
+}
+
+extension LocalWeekFinderMoment on Moment {
+  /// Assumes [this] is in local timezone, but will preserve the timezone
+  Moment startOfNextLocalWeek([int? weekStart]) => forcedSuperType
+      .startOfNextLocalWeek(weekStart ?? localization.weekStart)
+      .toMoment(localization: setLocalization);
+
+  /// Assumes [this] is in local timezone, but will preserve the timezone
+  Moment startOfLastLocalWeek([int? weekStart]) => forcedSuperType
+      .startOfLastLocalWeek(weekStart ?? localization.weekStart)
+      .toMoment(localization: setLocalization);
+
+  /// Assumes [this] is in local timezone, but will preserve the timezone
+  Moment endOfNextLocalWeek([int? weekStart]) => forcedSuperType
+      .endOfNextLocalWeek(weekStart ?? localization.weekStart)
+      .toMoment(localization: setLocalization);
+
+  /// Assumes [this] is in local timezone, but will preserve the timezone
+  Moment endOfLastLocalWeek([int? weekStart]) => forcedSuperType
+      .endOfLastLocalWeek(weekStart ?? localization.weekStart)
+      .toMoment(localization: setLocalization);
+}
+
+extension IsoWeekFinderMoment on Moment {
+  /// Assumes [this] is in local timezone, but will preserve the timezone
+  Moment startOfNextIsoWeek() => forcedSuperType
+      .startOfNextLocalWeek(DateTime.monday)
+      .toMoment(localization: setLocalization);
+
+  /// Assumes [this] is in local timezone, but will preserve the timezone
+  Moment startOfLastIsoWeek() => forcedSuperType
+      .startOfLastLocalWeek(DateTime.monday)
+      .toMoment(localization: setLocalization);
+
+  /// Assumes [this] is in local timezone, but will preserve the timezone
+  Moment endOfNextIsoWeek() => forcedSuperType
+      .endOfNextLocalWeek(DateTime.monday)
+      .toMoment(localization: setLocalization);
+
+  /// Assumes [this] is in local timezone, but will preserve the timezone
+  Moment endOfLastIsoWeek() => forcedSuperType
+      .endOfLastLocalWeek(DateTime.monday)
+      .toMoment(localization: setLocalization);
+}
+
+extension DayFinderMoment on Moment {
+  /// Returns a new [Moment] of same timezone
+  Moment startOfNextDay() =>
+      forcedSuperType.startOfNextDay().toMoment(localization: setLocalization);
+
+  /// Returns a new [Moment] of same timezone
+  Moment startOfLastDay() =>
+      forcedSuperType.startOfLastDay().toMoment(localization: setLocalization);
+
+  /// Returns a new [Moment] of same timezone
+  Moment endOfNextDay() =>
+      forcedSuperType.endOfNextDay().toMoment(localization: setLocalization);
+
+  /// Returns a new [Moment] of same timezone
+  Moment endOfLastDay() =>
+      forcedSuperType.endOfLastDay().toMoment(localization: setLocalization);
+}
+
+extension HourFinderMoment on Moment {
+  /// Returns a new [Moment] of same timezone
+  Moment startOfNextHour() =>
+      forcedSuperType.startOfNextHour().toMoment(localization: setLocalization);
+
+  /// Returns a new [Moment] of same timezone
+  Moment startOfLastHour() =>
+      forcedSuperType.startOfLastHour().toMoment(localization: setLocalization);
+
+  /// Returns a new [Moment] of same timezone
+  Moment endOfNextHour() =>
+      forcedSuperType.endOfNextHour().toMoment(localization: setLocalization);
+
+  /// Returns a new [Moment] of same timezone
+  Moment endOfLastHour() =>
+      forcedSuperType.endOfLastHour().toMoment(localization: setLocalization);
+}
+
+extension MinuteFinderMoment on Moment {
+  /// Returns a new [Moment] of same timezone
+  Moment startOfNextMinute() => forcedSuperType
+      .startOfNextMinute()
+      .toMoment(localization: setLocalization);
+
+  /// Returns a new [Moment] of same timezone
+  Moment startOfLastMinute() => forcedSuperType
+      .startOfLastMinute()
+      .toMoment(localization: setLocalization);
+
+  /// Returns a new [Moment] of same timezone
+  Moment endOfNextMinute() =>
+      forcedSuperType.endOfNextMinute().toMoment(localization: setLocalization);
+
+  /// Returns a new [Moment] of same timezone
+  Moment endOfLastMinute() =>
+      forcedSuperType.endOfLastMinute().toMoment(localization: setLocalization);
+}

--- a/lib/src/extensions/start_of.dart
+++ b/lib/src/extensions/start_of.dart
@@ -1,5 +1,4 @@
 import 'package:moment_dart/src/exception.dart';
-import 'package:moment_dart/src/extensions/constructor.dart';
 import 'package:moment_dart/src/moment.dart';
 
 extension StartOfUnit on DateTime {
@@ -116,6 +115,11 @@ extension StartOfUnit on DateTime {
     return subtract(Duration(days: delta)).startOfDay();
   }
 
+  /// Returns start of the ISO week (always Monday)
+  ///
+  /// Returned object will have same timezone as [this]
+  DateTime startOfIsoWeek() => startOfLocalWeek(DateTime.monday);
+
   /// Returns start of the month
   ///
   /// Returned object will have same timezone as [this]
@@ -183,6 +187,11 @@ extension StartOfUnitMoment on Moment {
         .startOfLocalWeek(weekStart ?? localization.weekStart)
         .toMoment(localization: setLocalization);
   }
+
+  /// Returns start of the ISO week (always Monday)
+  ///
+  /// Returned object will have same timezone as [this]
+  Moment startOfIsoWeek() => startOfLocalWeek(DateTime.monday);
 
   /// Returns start of the month
   ///

--- a/lib/src/formatters/token.dart
+++ b/lib/src/formatters/token.dart
@@ -161,22 +161,6 @@ enum FormatterToken {
   /// [DateTime] complies ISO 8601 standard, therefore Moment.js's YYYYYY, Y are redundant
   YYYY,
 
-  /// [Year]
-  ///
-  /// -001970 -001971 ... +001907 +001971
-  ///
-  /// Note: Expanded Years (Covering the full time value range of approximately 273,790 years forward or backward from 01 January, 1970)
-  @Deprecated("[DateTime] complies ISO 8601 standard, so, please use YYYY")
-  YYYYYY,
-
-  /// [Year]
-  ///
-  /// 1970 1971 ... 9999 +10000 +10001
-  ///
-  /// Note: This complies with the ISO 8601 standard for dates past the year 9999
-  @Deprecated("[DateTime] complies ISO 8601 standard, so, please use YYYY")
-  Y,
-
   /// [Era Year]
   ///
   /// 1 2 ... 2020 ...

--- a/lib/src/localizations/ja_JP.dart
+++ b/lib/src/localizations/ja_JP.dart
@@ -2,7 +2,6 @@
 // Author: Batmend Ganbaatar (https://github.com/sadespresso)
 
 import 'package:moment_dart/src/extensions.dart';
-import 'package:moment_dart/src/extensions/constructor.dart';
 import 'package:moment_dart/src/localizations/mixins/complex_calendar.dart';
 import 'package:moment_dart/src/localizations/mixins/simple_duration.dart';
 import 'package:moment_dart/src/localizations/mixins/simple_relative.dart';

--- a/lib/src/localizations/zh_CN.dart
+++ b/lib/src/localizations/zh_CN.dart
@@ -2,7 +2,6 @@
 // Author: Batmend Ganbaatar (https://github.com/sadespresso)
 
 import 'package:moment_dart/src/extensions.dart';
-import 'package:moment_dart/src/extensions/constructor.dart';
 import 'package:moment_dart/src/localization.dart';
 import 'package:moment_dart/src/localizations/mixins/complex_calendar.dart';
 import 'package:moment_dart/src/localizations/mixins/month_names.dart';

--- a/lib/src/moment.dart
+++ b/lib/src/moment.dart
@@ -2,7 +2,6 @@ export 'package:moment_dart/src/extensions.dart';
 export 'package:moment_dart/src/time_range.dart';
 
 import 'package:moment_dart/moment_dart.dart';
-import 'package:moment_dart/src/extensions/constructor.dart';
 import 'package:moment_dart/src/formatters/format_match.dart';
 
 /// A subclass of DateTime. Therefore:
@@ -450,108 +449,126 @@ class Moment extends DateTime {
         minutes.toString();
   }
 
+  /// Start of the current hour in the local timezone
+  static DateTime startOfThisHour() => DateTime.now().startOfHour();
+
+  /// Start of the next hour in the local timezone
+  static DateTime startOfNextHour() => DateTime.now().startOfNextHour();
+
+  /// Start of the last hour in the local timezone
+  static DateTime startOfLastHour() => DateTime.now().startOfLastHour();
+
   /// Start of today in the local timezone
   static DateTime startOfToday() => DateTime.now().startOfDay();
 
   /// Start of tomorrow in the local timezone
 
-  static DateTime startOfTomorrow() {
-    final DateTime now = DateTime.now();
-
-    return DateTime(now.year, now.month, now.day + 1);
-  }
+  static DateTime startOfTomorrow() => DateTime.now().startOfNextDay();
 
   /// Start of yesterday in the local timezone
-  static DateTime startOfYesterday() {
-    final DateTime now = DateTime.now();
+  static DateTime startOfYesterday() => DateTime.now().startOfLastDay();
 
-    return DateTime(now.year, now.month, now.day - 1);
-  }
+  /// Start of the current local week in the local timezone
+  static DateTime startOfThisLocalWeek([int? weekStart]) =>
+      DateTime.now().startOfLocalWeek(weekStart);
+
+  /// Start of the next local week in the local timezone
+  static DateTime startOfNextLocalWeek([int? weekStart]) =>
+      DateTime.now().startOfNextLocalWeek(weekStart);
+
+  /// Start of the last local week in the local timezone
+  static DateTime startOfLastLocalWeek([int? weekStart]) =>
+      DateTime.now().startOfLastLocalWeek(weekStart);
+
+  /// Start of the current ISO week in the local timezone
+  static DateTime startOfThisIsoWeek() =>
+      DateTime.now().startOfLocalWeek(DateTime.monday);
+
+  /// Start of the next ISO week in the local timezone
+  static DateTime startOfNextIsoWeek() =>
+      DateTime.now().startOfNextLocalWeek(DateTime.monday);
+
+  /// Start of the last ISO week in the local timezone
+  static DateTime startOfLastIsoWeek() =>
+      DateTime.now().startOfLastLocalWeek(DateTime.monday);
 
   /// Start of the current month in the local timezone
   static DateTime startOfThisMonth() => DateTime.now().startOfMonth();
 
   /// Start of the next month in the local timezone
-  static DateTime startOfNextMonth() {
-    final DateTime now = DateTime.now();
-
-    return DateTime(now.year, now.month + 1);
-  }
+  static DateTime startOfNextMonth() => DateTime.now().startOfNextMonth();
 
   /// Start of the previous month in the local timezone
-  static DateTime startOfPrevMonth() {
-    final DateTime now = DateTime.now();
-
-    return DateTime(now.year, now.month - 1);
-  }
+  static DateTime startOfLastMonth() => DateTime.now().startOfLastMonth();
 
   /// Start of the current year in the local timezone
   static DateTime startOfThisYear() => DateTime.now().startOfYear();
 
   /// Start of the next year in the local timezone
-  static DateTime startOfNextYear() {
-    final DateTime now = DateTime.now();
-
-    return DateTime(now.year + 1);
-  }
+  static DateTime startOfNextYear() => DateTime.now().startOfNextYear();
 
   /// Start of the previous year in the local timezone
-  static DateTime startOfPrevYear() {
-    final DateTime now = DateTime.now();
+  static DateTime startOfLastYear() => DateTime.now().startOfLastYear();
 
-    return DateTime(now.year - 1);
-  }
+  /// End of the current hour in the local timezone
+  static DateTime endOfThisHour() => DateTime.now().endOfHour();
+
+  /// End of the next hour in the local timezone
+  static DateTime endOfNextHour() => DateTime.now().endOfNextHour();
+
+  /// End of the last hour in the local timezone
+  static DateTime endOfLastHour() => DateTime.now().endOfLastHour();
 
   /// End of today in the local timezone
   static DateTime endOfToday() => DateTime.now().endOfDay();
 
   /// End of tomorrow in the local timezone
-  static DateTime endOfTomorrow() {
-    final DateTime now = DateTime.now();
-
-    return DateTime(now.year, now.month, now.day + 1, 23, 59, 59, 999, 999);
-  }
+  static DateTime endOfTomorrow() => DateTime.now().endOfNextDay();
 
   /// End of yesterday in the local timezone
-  static DateTime endOfYesterday() {
-    final DateTime now = DateTime.now();
+  static DateTime endOfYesterday() => DateTime.now().endOfLastDay();
 
-    return DateTime(now.year, now.month, now.day - 1, 23, 59, 59, 999, 999);
-  }
+  /// End of the current local week in the local timezone
+  static DateTime endOfThisLocalWeek([int? weekStart]) =>
+      DateTime.now().endOfLocalWeek(weekStart);
+
+  /// End of the next local week in the local timezone
+  static DateTime endOfNextLocalWeek([int? weekStart]) =>
+      DateTime.now().endOfNextLocalWeek(weekStart);
+
+  /// End of the last local week in the local timezone
+  static DateTime endOfLastLocalWeek([int? weekStart]) =>
+      DateTime.now().endOfLastLocalWeek(weekStart);
+
+  /// End of the current ISO week in the local timezone
+  static DateTime endOfThisIsoWeek() =>
+      DateTime.now().endOfLocalWeek(DateTime.monday);
+
+  /// End of the next ISO week in the local timezone
+  static DateTime endOfNextIsoWeek() =>
+      DateTime.now().endOfNextLocalWeek(DateTime.monday);
+
+  /// End of the last ISO week in the local timezone
+  static DateTime endOfLastIsoWeek() =>
+      DateTime.now().endOfLastLocalWeek(DateTime.monday);
 
   /// End of the current month in the local timezone
   static DateTime endOfThisMonth() => DateTime.now().endOfMonth();
 
   /// End of the next month in the local timezone
-  static DateTime endOfNextMonth() {
-    final DateTime now = DateTime.now();
-
-    return DateTime(now.year, now.month + 1).endOfMonth();
-  }
+  static DateTime endOfNextMonth() => DateTime.now().endOfNextMonth();
 
   /// End of the previous month in the local timezone
-  static DateTime endOfPrevMonth() {
-    final DateTime now = DateTime.now();
-
-    return DateTime(now.year, now.month - 1).endOfMonth();
-  }
+  static DateTime endOfLastMonth() => DateTime.now().endOfLastMonth();
 
   /// End of the current year in the local timezone
   static DateTime endOfThisYear() => DateTime.now().endOfYear();
 
   /// End of the next year in the local timezone
-  static DateTime endOfNextYear() {
-    final DateTime now = DateTime.now();
-
-    return DateTime(now.year + 1, 12, 31, 23, 59, 59, 999, 999);
-  }
+  static DateTime endOfNextYear() => DateTime.now().endOfNextYear();
 
   /// End of the previous year in the local timezone
-  static DateTime endOfPrevYear() {
-    final DateTime now = DateTime.now();
-
-    return DateTime(now.year - 1, 12, 31, 23, 59, 59, 999, 999);
-  }
+  static DateTime endOfLastYear() => DateTime.now().endOfLastYear();
 
   /// epoch, but in the local timezone
   static DateTime epoch = DateTime.fromMicrosecondsSinceEpoch(0);

--- a/lib/src/time_range.dart
+++ b/lib/src/time_range.dart
@@ -1,5 +1,11 @@
 import 'package:moment_dart/moment_dart.dart';
-import 'package:moment_dart/src/extensions/constructor.dart';
+
+export 'time_range/hour.dart';
+export 'time_range/day.dart';
+export 'time_range/week.dart';
+export 'time_range/month.dart';
+export 'time_range/year.dart';
+export 'time_range/custom.dart';
 
 abstract class TimeRange {
   const TimeRange();
@@ -42,37 +48,49 @@ abstract class TimeRange {
   TimeRange toUtc();
 
   /// In the local timezone
-  factory TimeRange.today() => DayTimeRange.fromDateTime(DateTime.now());
+  static HourTimeRange thisHour() => HourTimeRange.fromDateTime(DateTime.now());
 
   /// In the local timezone
-  factory TimeRange.tomorrow() =>
+  static HourTimeRange nextHour() =>
+      HourTimeRange.fromDateTime(Moment.startOfNextHour());
+
+  /// In the local timezone
+  static HourTimeRange lastHour() =>
+      HourTimeRange.fromDateTime(Moment.startOfLastHour());
+
+  /// In the local timezone
+  static DayTimeRange today() => DayTimeRange.fromDateTime(DateTime.now());
+
+  /// In the local timezone
+  static DayTimeRange tomorrow() =>
       DayTimeRange.fromDateTime(Moment.startOfTomorrow());
 
   /// In the local timezone
-  factory TimeRange.yesterday() =>
+  static DayTimeRange yesterday() =>
       DayTimeRange.fromDateTime(Moment.startOfYesterday());
 
   /// In the local timezone
-  factory TimeRange.thisMonth() => MonthTimeRange.fromDateTime(DateTime.now());
+  static MonthTimeRange thisMonth() =>
+      MonthTimeRange.fromDateTime(DateTime.now());
 
   /// In the local timezone
-  factory TimeRange.nextMonth() =>
+  static MonthTimeRange nextMonth() =>
       MonthTimeRange.fromDateTime(Moment.startOfNextMonth());
 
   /// In the local timezone
-  factory TimeRange.prevMonth() =>
-      MonthTimeRange.fromDateTime(Moment.startOfPrevMonth());
+  static MonthTimeRange lastMonth() =>
+      MonthTimeRange.fromDateTime(Moment.startOfLastMonth());
 
   /// In the local timezone
-  factory TimeRange.thisYear() => YearTimeRange.fromDateTime(DateTime.now());
+  static YearTimeRange thisYear() => YearTimeRange.fromDateTime(DateTime.now());
 
   /// In the local timezone
-  factory TimeRange.nextYear() =>
+  static YearTimeRange nextYear() =>
       YearTimeRange.fromDateTime(Moment.startOfNextYear());
 
   /// In the local timezone
-  factory TimeRange.prevYear() =>
-      YearTimeRange.fromDateTime(Moment.startOfPrevYear());
+  static YearTimeRange lastYear() =>
+      YearTimeRange.fromDateTime(Moment.startOfLastYear());
 
   @override
   bool operator ==(Object other) {
@@ -89,140 +107,4 @@ abstract class TimeRange {
 
   @override
   String toString() => "TimeRange($from -> $to)";
-}
-
-class CustomTimeRange extends TimeRange {
-  @override
-
-  /// Returns if [from] is in UTC timezone.
-  ///
-  /// Does NOT check it [to] is in UTC timezone.
-  bool get isUtc => from.isUtc;
-
-  @override
-  final DateTime from;
-  @override
-  final DateTime to;
-
-  /// The timezone is assumed by the [from] passed in here.
-  ///
-  /// [CustomTimeRange] does NOT ensure that [from] and [to] have the same timezone.
-  const CustomTimeRange(this.from, this.to)
-      : assert(from <= to, "[from] must be before or equal to [to]");
-
-  @override
-  CustomTimeRange toUtc() =>
-      isUtc ? this : CustomTimeRange(from.toUtc(), to.toUtc());
-}
-
-class DayTimeRange extends TimeRange {
-  @override
-  final bool isUtc;
-
-  final int year;
-  final int month;
-  final int day;
-
-  const DayTimeRange(
-    this.year,
-    this.month,
-    this.day, {
-    this.isUtc = false,
-  });
-
-  /// Will preserve the timezone of [dateTime]
-  factory DayTimeRange.fromDateTime(DateTime dateTime) => DayTimeRange(
-        dateTime.year,
-        dateTime.month,
-        dateTime.day,
-        isUtc: dateTime.isUtc,
-      );
-
-  @override
-  DateTime get from =>
-      DateTimeConstructors.withTimezone(isUtc, year, month, day);
-
-  @override
-  DateTime get to => from.endOfDay();
-
-  @override
-  DayTimeRange toUtc() =>
-      isUtc ? this : DayTimeRange(year, month, day, isUtc: true);
-}
-
-class LocalWeekTimeRange extends CustomTimeRange {
-  LocalWeekTimeRange(DateTime dateTime)
-      : super(dateTime.startOfLocalWeek(), dateTime.endOfLocalWeek());
-
-  @override
-  CustomTimeRange toUtc() => throw UnsupportedError(
-      "Local week time range cannot be converted to UTC");
-}
-
-class IsoWeekTimeRange extends CustomTimeRange {
-  IsoWeekTimeRange(DateTime dateTime)
-      : super(dateTime.startOfLocalWeek(1), dateTime.endOfLocalWeek(1));
-
-  int get weekYear => from.weekYear;
-  int get week => from.week;
-
-  @override
-  CustomTimeRange toUtc() => throw UnsupportedError(
-      "Local week time range cannot be converted to UTC");
-}
-
-class MonthTimeRange extends TimeRange {
-  @override
-  final bool isUtc;
-
-  final int year;
-  final int month;
-
-  const MonthTimeRange(
-    this.year,
-    this.month, {
-    this.isUtc = false,
-  });
-
-  /// Will preserve the timezone of [dateTime]
-  factory MonthTimeRange.fromDateTime(DateTime dateTime) => MonthTimeRange(
-        dateTime.year,
-        dateTime.month,
-        isUtc: dateTime.isUtc,
-      );
-
-  @override
-  DateTime get from => DateTimeConstructors.withTimezone(isUtc, year, month);
-
-  @override
-  DateTime get to => from.endOfMonth();
-
-  @override
-  MonthTimeRange toUtc() =>
-      isUtc ? this : MonthTimeRange(year, month, isUtc: true);
-}
-
-class YearTimeRange extends TimeRange {
-  @override
-  final bool isUtc;
-
-  final int year;
-
-  const YearTimeRange(
-    this.year, {
-    this.isUtc = false,
-  });
-
-  /// Will preserve the timezone of [dateTime]
-  factory YearTimeRange.fromDateTime(DateTime dateTime) =>
-      YearTimeRange(dateTime.year, isUtc: dateTime.isUtc);
-
-  @override
-  DateTime get from => DateTimeConstructors.withTimezone(isUtc, year);
-
-  @override
-  DateTime get to => from.endOfYear();
-
-  @override
-  YearTimeRange toUtc() => isUtc ? this : YearTimeRange(year, isUtc: true);
 }

--- a/lib/src/time_range/custom.dart
+++ b/lib/src/time_range/custom.dart
@@ -1,0 +1,26 @@
+import 'package:moment_dart/src/extensions.dart';
+import 'package:moment_dart/src/time_range.dart';
+
+class CustomTimeRange extends TimeRange {
+  @override
+
+  /// Returns if [from] is in UTC timezone.
+  ///
+  /// Does NOT check it [to] is in UTC timezone.
+  bool get isUtc => from.isUtc;
+
+  @override
+  final DateTime from;
+  @override
+  final DateTime to;
+
+  /// The timezone is assumed by the [from] passed in here.
+  ///
+  /// [CustomTimeRange] does NOT ensure that [from] and [to] have the same timezone.
+  const CustomTimeRange(this.from, this.to)
+      : assert(from <= to, "[from] must be before or equal to [to]");
+
+  @override
+  CustomTimeRange toUtc() =>
+      isUtc ? this : CustomTimeRange(from.toUtc(), to.toUtc());
+}

--- a/lib/src/time_range/day.dart
+++ b/lib/src/time_range/day.dart
@@ -1,0 +1,44 @@
+import 'package:moment_dart/src/extensions.dart';
+import 'package:moment_dart/src/time_range.dart';
+import 'package:moment_dart/src/time_range/pageable_range.dart';
+
+class DayTimeRange extends TimeRange with PageableRange<DayTimeRange> {
+  @override
+  final bool isUtc;
+
+  final int year;
+  final int month;
+  final int day;
+
+  const DayTimeRange(
+    this.year,
+    this.month,
+    this.day, {
+    this.isUtc = false,
+  });
+
+  /// Will preserve the timezone of [dateTime]
+  factory DayTimeRange.fromDateTime(DateTime dateTime) => DayTimeRange(
+        dateTime.year,
+        dateTime.month,
+        dateTime.day,
+        isUtc: dateTime.isUtc,
+      );
+
+  @override
+  DateTime get from =>
+      DateTimeConstructors.withTimezone(isUtc, year, month, day);
+
+  @override
+  DateTime get to => from.startOfNextDay();
+
+  @override
+  DayTimeRange toUtc() =>
+      isUtc ? this : DayTimeRange(year, month, day, isUtc: true);
+
+  @override
+  DayTimeRange get next => DayTimeRange(year, month, day + 1, isUtc: isUtc);
+
+  @override
+  DayTimeRange get last => DayTimeRange(year, month, day - 1, isUtc: isUtc);
+}

--- a/lib/src/time_range/hour.dart
+++ b/lib/src/time_range/hour.dart
@@ -1,0 +1,59 @@
+import 'package:moment_dart/src/extensions.dart';
+import 'package:moment_dart/src/time_range.dart';
+import 'package:moment_dart/src/time_range/pageable_range.dart';
+
+class HourTimeRange extends TimeRange with PageableRange<HourTimeRange> {
+  @override
+  final bool isUtc;
+
+  final int year;
+  final int month;
+  final int day;
+  final int hour;
+
+  const HourTimeRange(
+    this.year,
+    this.month,
+    this.day,
+    this.hour, {
+    this.isUtc = false,
+  });
+
+  /// Will preserve the timezone of [dateTime]
+  factory HourTimeRange.fromDateTime(DateTime dateTime) => HourTimeRange(
+        dateTime.year,
+        dateTime.month,
+        dateTime.day,
+        dateTime.hour,
+        isUtc: dateTime.isUtc,
+      );
+
+  @override
+  DateTime get from =>
+      DateTimeConstructors.withTimezone(isUtc, year, month, day, hour);
+
+  @override
+  DateTime get to => from.startOfNextHour();
+
+  @override
+  HourTimeRange toUtc() =>
+      isUtc ? this : HourTimeRange(year, month, day, hour, isUtc: true);
+
+  @override
+  HourTimeRange get next => HourTimeRange(
+        year,
+        month,
+        day,
+        hour + 1,
+        isUtc: isUtc,
+      );
+
+  @override
+  HourTimeRange get last => HourTimeRange(
+        year,
+        month,
+        day,
+        hour - 1,
+        isUtc: isUtc,
+      );
+}

--- a/lib/src/time_range/month.dart
+++ b/lib/src/time_range/month.dart
@@ -1,0 +1,40 @@
+import 'package:moment_dart/src/extensions.dart';
+import 'package:moment_dart/src/time_range.dart';
+import 'package:moment_dart/src/time_range/pageable_range.dart';
+
+class MonthTimeRange extends TimeRange with PageableRange<MonthTimeRange> {
+  @override
+  final bool isUtc;
+
+  final int year;
+  final int month;
+
+  const MonthTimeRange(
+    this.year,
+    this.month, {
+    this.isUtc = false,
+  });
+
+  /// Will preserve the timezone of [dateTime]
+  factory MonthTimeRange.fromDateTime(DateTime dateTime) => MonthTimeRange(
+        dateTime.year,
+        dateTime.month,
+        isUtc: dateTime.isUtc,
+      );
+
+  @override
+  DateTime get from => DateTimeConstructors.withTimezone(isUtc, year, month);
+
+  @override
+  DateTime get to => from.startOfNextMonth();
+
+  @override
+  MonthTimeRange toUtc() =>
+      isUtc ? this : MonthTimeRange(year, month, isUtc: true);
+
+  @override
+  MonthTimeRange get next => MonthTimeRange(year, month + 1, isUtc: isUtc);
+
+  @override
+  MonthTimeRange get last => MonthTimeRange(year, month - 1, isUtc: isUtc);
+}

--- a/lib/src/time_range/pageable_range.dart
+++ b/lib/src/time_range/pageable_range.dart
@@ -1,0 +1,10 @@
+import 'package:moment_dart/moment_dart.dart';
+import 'package:moment_dart/src/time_range.dart';
+
+mixin PageableRange<T extends TimeRange> on TimeRange {
+  /// Returns a new instance, preserves the timezone
+  T get next;
+
+  /// Returns a new instance, preserves the timezone
+  T get last;
+}

--- a/lib/src/time_range/week.dart
+++ b/lib/src/time_range/week.dart
@@ -1,0 +1,41 @@
+import 'package:moment_dart/src/extensions.dart';
+import 'package:moment_dart/src/time_range/custom.dart';
+import 'package:moment_dart/src/time_range/pageable_range.dart';
+
+class LocalWeekTimeRange extends CustomTimeRange
+    implements PageableRange<LocalWeekTimeRange> {
+  LocalWeekTimeRange(DateTime dateTime, [int? weekStart])
+      : super(
+          dateTime.startOfLocalWeek(weekStart),
+          dateTime.startOfNextLocalWeek(weekStart),
+        );
+
+  @override
+  CustomTimeRange toUtc() => throw UnsupportedError(
+      "Local week time range cannot be converted to UTC");
+
+  @override
+  LocalWeekTimeRange get next => throw UnimplementedError();
+
+  @override
+  LocalWeekTimeRange get last => throw UnimplementedError();
+}
+
+class IsoWeekTimeRange extends CustomTimeRange
+    with PageableRange<IsoWeekTimeRange> {
+  IsoWeekTimeRange(DateTime dateTime)
+      : super(dateTime.startOfLocalWeek(1), dateTime.startOfNextLocalWeek(1));
+
+  int get weekYear => from.weekYear;
+  int get week => from.week;
+
+  @override
+  CustomTimeRange toUtc() =>
+      throw UnsupportedError("ISO week time range cannot be converted to UTC");
+
+  @override
+  IsoWeekTimeRange get next => IsoWeekTimeRange(from.nextMonday());
+
+  @override
+  IsoWeekTimeRange get last => IsoWeekTimeRange(from.lastMonday());
+}

--- a/lib/src/time_range/year.dart
+++ b/lib/src/time_range/year.dart
@@ -1,0 +1,34 @@
+import 'package:moment_dart/src/extensions.dart';
+import 'package:moment_dart/src/time_range.dart';
+import 'package:moment_dart/src/time_range/pageable_range.dart';
+
+class YearTimeRange extends TimeRange with PageableRange<YearTimeRange> {
+  @override
+  final bool isUtc;
+
+  final int year;
+
+  const YearTimeRange(
+    this.year, {
+    this.isUtc = false,
+  });
+
+  /// Will preserve the timezone of [dateTime]
+  factory YearTimeRange.fromDateTime(DateTime dateTime) =>
+      YearTimeRange(dateTime.year, isUtc: dateTime.isUtc);
+
+  @override
+  DateTime get from => DateTimeConstructors.withTimezone(isUtc, year);
+
+  @override
+  DateTime get to => from.startOfNextYear();
+
+  @override
+  YearTimeRange toUtc() => isUtc ? this : YearTimeRange(year, isUtc: true);
+
+  @override
+  YearTimeRange get next => YearTimeRange(year + 1, isUtc: isUtc);
+
+  @override
+  YearTimeRange get last => YearTimeRange(year - 1, isUtc: isUtc);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: moment_dart
 description: Multi-purpose immutable DateTime subclass. Supports multiple localizations to easily convert DateTime and Duration into human-readable format
-version: 1.2.0
+version: 2.0.0
 homepage: https://github.com/sadespresso/moment_dart
 issue_tracker: https://github.com/sadespresso/moment_dart/issues
 funding:

--- a/test/extensions/relative_finder_test.dart
+++ b/test/extensions/relative_finder_test.dart
@@ -1,0 +1,219 @@
+import 'package:moment_dart/moment_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // Sunday as the start of the week
+  Moment.setGlobalLocalization(LocalizationEnUs());
+
+  group('YearFinder', () {
+    test('startOfNextYear', () {
+      final date = DateTime(2022);
+      final nextYear = date.startOfNextYear();
+      expect(nextYear.year, 2023);
+      expect(nextYear.month, 1);
+      expect(nextYear.day, 1);
+    });
+
+    test('startOfLastYear', () {
+      final date = DateTime(2022);
+      final lastYear = date.startOfLastYear();
+      expect(lastYear.year, 2021);
+      expect(lastYear.month, 1);
+      expect(lastYear.day, 1);
+    });
+
+    test('endOfNextYear', () {
+      final date = DateTime(2022);
+      final endNextYear = date.endOfNextYear();
+      expect(endNextYear.year, 2023);
+      expect(endNextYear.month, 12);
+      expect(endNextYear.day, 31);
+    });
+
+    test('endOfLastYear', () {
+      final date = DateTime(2022);
+      final endLastYear = date.endOfLastYear();
+      expect(endLastYear.year, 2021);
+      expect(endLastYear.month, 12);
+      expect(endLastYear.day, 31);
+    });
+    test('endOfNextYear', () {
+      final date = DateTime(2022);
+      final endLastYear = date.endOfNextYear();
+      expect(endLastYear.year, 2023);
+      expect(endLastYear.month, 12);
+      expect(endLastYear.day, 31);
+    });
+  });
+
+  group('MonthFinder', () {
+    test('startOfNextMonth', () {
+      final date = DateTime(2022, 5);
+      final nextMonth = date.startOfNextMonth();
+      expect(nextMonth.year, 2022);
+      expect(nextMonth.month, 6);
+      expect(nextMonth.day, 1);
+    });
+    test('startOfLastMonth', () {
+      final date = DateTime(2022, 5);
+      final lastMonth = date.startOfLastMonth();
+      expect(lastMonth.year, 2022);
+      expect(lastMonth.month, 4);
+      expect(lastMonth.day, 1);
+    });
+    test('endOfNextMonth', () {
+      final date = DateTime(2022, 5);
+      final nextMonth = date.endOfNextMonth();
+      expect(nextMonth.year, 2022);
+      expect(nextMonth.month, 6);
+      expect(nextMonth.day, 30);
+    });
+    test('endOfLastMonth', () {
+      final date = DateTime(2022, 5);
+      final lastMonth = date.endOfLastMonth();
+      expect(lastMonth.year, 2022);
+      expect(lastMonth.month, 4);
+      expect(lastMonth.day, 30);
+    });
+  });
+  group('LocalWeekFinder', () {
+    test('startOfNextWeek', () {
+      final date = DateTime(2022, 5, 5);
+      final nextWeek = date.startOfNextLocalWeek();
+      expect(nextWeek.year, 2022);
+      expect(nextWeek.month, 5);
+      expect(nextWeek.day, 8);
+    });
+    test('startOfLastWeek', () {
+      final date = DateTime(2022, 5, 5);
+      final lastWeek = date.startOfLastLocalWeek();
+      expect(lastWeek.year, 2022);
+      expect(lastWeek.month, 4);
+      expect(lastWeek.day, 24);
+    });
+    test('endOfNextWeek', () {
+      final date = DateTime(2022, 5, 5);
+      final nextWeek = date.endOfNextLocalWeek();
+      expect(nextWeek.year, 2022);
+      expect(nextWeek.month, 5);
+      expect(nextWeek.day, 14);
+    });
+    test('endOfLastWeek', () {
+      final date = DateTime(2022, 5, 5);
+      final lastWeek = date.endOfLastLocalWeek();
+      expect(lastWeek.year, 2022);
+      expect(lastWeek.month, 4);
+      expect(lastWeek.day, 30);
+    });
+  });
+  group("IsoWeekFinder", () {
+    test('startOfNextIsoWeek', () {
+      final date = DateTime(2022, 5, 5);
+      final nextWeek = date.startOfNextIsoWeek();
+      expect(nextWeek.year, 2022);
+      expect(nextWeek.month, 5);
+      expect(nextWeek.day, 9);
+    });
+    test('startOfLastIsoWeek', () {
+      final date = DateTime(2022, 5, 5);
+      final lastWeek = date.startOfLastIsoWeek();
+      expect(lastWeek.year, 2022);
+      expect(lastWeek.month, 4);
+      expect(lastWeek.day, 25);
+    });
+    test('endOfNextIsoWeek', () {
+      final date = DateTime(2022, 5, 5);
+      final nextWeek = date.endOfNextIsoWeek();
+      expect(nextWeek.year, 2022);
+      expect(nextWeek.month, 5);
+      expect(nextWeek.day, 15);
+    });
+    test('endOfLastIsoWeek', () {
+      final date = DateTime(2022, 5, 5);
+      final lastWeek = date.endOfLastIsoWeek();
+      expect(lastWeek.year, 2022);
+      expect(lastWeek.month, 5);
+      expect(lastWeek.day, 1);
+    });
+  });
+  group("DayFinder", () {
+    test('startOfNextDay', () {
+      final date = DateTime(2022, 5, 5);
+      final nextDay = date.startOfNextDay();
+      expect(nextDay.year, 2022);
+      expect(nextDay.month, 5);
+      expect(nextDay.day, 6);
+    });
+    test('startOfLastDay', () {
+      final date = DateTime(2022, 5, 5);
+      final lastDay = date.startOfLastDay();
+      expect(lastDay.year, 2022);
+      expect(lastDay.month, 5);
+      expect(lastDay.day, 4);
+    });
+    test('endOfNextDay', () {
+      final date = DateTime(2022, 5, 5);
+      final nextDay = date.endOfNextDay();
+      expect(nextDay.year, 2022);
+      expect(nextDay.month, 5);
+      expect(nextDay.day, 6);
+    });
+    test('endOfLastDay', () {
+      final date = DateTime(2022, 5, 5);
+      final lastDay = date.endOfLastDay();
+      expect(lastDay.year, 2022);
+      expect(lastDay.month, 5);
+      expect(lastDay.day, 4);
+    });
+  });
+  group("HourFinder", () {
+    test('startOfNextHour', () {
+      final date = DateTime(2022, 5, 5, 5);
+      final nextHour = date.startOfNextHour();
+      expect(nextHour.year, 2022);
+      expect(nextHour.month, 5);
+      expect(nextHour.day, 5);
+      expect(nextHour.hour, 6);
+      expect(nextHour.minute, 0);
+      expect(nextHour.second, 0);
+      expect(nextHour.millisecond, 0);
+      expect(nextHour.microsecond, 0);
+    });
+    test('startOfLastHour', () {
+      final date = DateTime(2022, 5, 5, 5);
+      final lastHour = date.startOfLastHour();
+      expect(lastHour.year, 2022);
+      expect(lastHour.month, 5);
+      expect(lastHour.day, 5);
+      expect(lastHour.hour, 4);
+      expect(lastHour.minute, 0);
+      expect(lastHour.second, 0);
+      expect(lastHour.millisecond, 0);
+      expect(lastHour.microsecond, 0);
+    });
+    test('endOfNextHour', () {
+      final date = DateTime(2022, 5, 5, 5);
+      final nextHour = date.endOfNextHour();
+      expect(nextHour.year, 2022);
+      expect(nextHour.month, 5);
+      expect(nextHour.day, 5);
+      expect(nextHour.hour, 6);
+      expect(nextHour.minute, 59);
+      expect(nextHour.second, 59);
+      expect(nextHour.millisecond, 999);
+      expect(nextHour.microsecond, 999);
+    });
+    test('endOfLastHour', () {
+      final date = DateTime(2022, 5, 5, 5);
+      final lastHour = date.endOfLastHour();
+      expect(lastHour.year, 2022);
+      expect(lastHour.month, 5);
+      expect(lastHour.day, 5);
+      expect(lastHour.hour, 4);
+      expect(lastHour.minute, 59);
+      expect(lastHour.second, 59);
+      expect(lastHour.millisecond, 999);
+      expect(lastHour.microsecond, 999);
+    });
+  });
+}

--- a/test/general_test.dart
+++ b/test/general_test.dart
@@ -314,6 +314,10 @@ void main() {
         DateTime(2022, 6, 19),
       ); // Sunday as start of week (since 0.16.0)
       expect(
+        m.startOfIsoWeek(),
+        DateTime(2022, 6, 13),
+      ); // Monday
+      expect(
           () => m.startOf(DurationUnit.week), throwsA(isA<MomentException>()));
       expect(m.startOfMonth(), DateTime(2022, 6));
       expect(m.startOfYear(), DateTime(2022));
@@ -332,6 +336,10 @@ void main() {
         m.startOfLocalWeek(),
         DateTime(2003, 6, 1).toMoment(),
       ); // Sunday as start of week, dervied from en_US locale
+      expect(
+        m.startOfIsoWeek(),
+        DateTime(2003, 5, 26).toMoment(),
+      ); // Monday
       expect(m.startOf(DurationUnit.week), m.startOfLocalWeek());
       expect(m.startOfMonth(), DateTime(2003, 6).toMoment());
       expect(m.startOfYear(), DateTime(2003).toMoment());
@@ -352,6 +360,10 @@ void main() {
         m.endOfLocalWeek(),
         DateTime(2022, 6, 25, 23, 59, 59, 999, 999),
       ); // Sunday as start of week (since 0.16.0)
+      expect(
+        m.endOfIsoWeek(),
+        DateTime(2022, 6, 19, 23, 59, 59, 999, 999),
+      ); // Monday as start of week for ISO
       expect(() => m.endOf(DurationUnit.week), throwsA(isA<MomentException>()));
       expect(m.endOfMonth(), DateTime(2022, 6, 30, 23, 59, 59, 999, 999));
       expect(m.endOfYear(), DateTime(2022, 12, 31, 23, 59, 59, 999, 999));
@@ -374,6 +386,10 @@ void main() {
         m.endOfLocalWeek(),
         DateTime(2003, 6, 7, 23, 59, 59, 999, 999).toMoment(),
       ); // Week start on Sunday, derived from en_US locale
+      expect(
+        m.endOfIsoWeek(),
+        DateTime(2003, 6, 1, 23, 59, 59, 999, 999).toMoment(),
+      ); // Week start on Monday for ISO
       expect(m.endOf(DurationUnit.week), m.endOfLocalWeek());
       expect(m.endOfMonth(),
           DateTime(2003, 6, 30, 23, 59, 59, 999, 999).toMoment());
@@ -450,10 +466,10 @@ void main() {
           DateTime(now.year, now.month, now.day - 1));
       expect(Moment.startOfThisMonth(), DateTime(now.year, now.month));
       expect(Moment.startOfNextMonth(), DateTime(now.year, now.month + 1));
-      expect(Moment.startOfPrevMonth(), DateTime(now.year, now.month - 1));
+      expect(Moment.startOfLastMonth(), DateTime(now.year, now.month - 1));
       expect(Moment.startOfThisYear(), DateTime(now.year));
       expect(Moment.startOfNextYear(), DateTime(now.year + 1));
-      expect(Moment.startOfPrevYear(), DateTime(now.year - 1));
+      expect(Moment.startOfLastYear(), DateTime(now.year - 1));
     });
 
     test("end of", () {
@@ -467,11 +483,11 @@ void main() {
           Moment.endOfThisMonth(), DateTime(now.year, now.month).endOfMonth());
       expect(Moment.endOfNextMonth(),
           DateTime(now.year, now.month + 1).endOfMonth());
-      expect(Moment.endOfPrevMonth(),
+      expect(Moment.endOfLastMonth(),
           DateTime(now.year, now.month - 1).endOfMonth());
       expect(Moment.endOfThisYear(), DateTime(now.year).endOfYear());
       expect(Moment.endOfNextYear(), DateTime(now.year + 1).endOfYear());
-      expect(Moment.endOfPrevYear(), DateTime(now.year - 1).endOfYear());
+      expect(Moment.endOfLastYear(), DateTime(now.year - 1).endOfYear());
     });
   });
 

--- a/test/time_range_test.dart
+++ b/test/time_range_test.dart
@@ -1,10 +1,8 @@
 import 'package:moment_dart/moment_dart.dart';
 import 'package:test/test.dart';
 
-/// One microsecond
-const aMicrosecond = Duration(microseconds: 1);
-
 void main() {
+  const aMicrosecond = Duration(microseconds: 1);
   group("Equality", () {
     final now = DateTime.now();
 
@@ -33,8 +31,8 @@ void main() {
         true,
       );
       expect(
-        TimeRange.prevMonth() ==
-            MonthTimeRange.fromDateTime(Moment.startOfPrevMonth()),
+        TimeRange.lastMonth() ==
+            MonthTimeRange.fromDateTime(Moment.startOfLastMonth()),
         true,
       );
       expect(
@@ -47,8 +45,8 @@ void main() {
         true,
       );
       expect(
-        TimeRange.prevYear() ==
-            YearTimeRange.fromDateTime(Moment.startOfPrevYear()),
+        TimeRange.lastYear() ==
+            YearTimeRange.fromDateTime(Moment.startOfLastYear()),
         true,
       );
     });
@@ -77,8 +75,8 @@ void main() {
         false,
       );
       expect(
-        TimeRange.prevMonth() ==
-            MonthTimeRange.fromDateTime(Moment.startOfPrevMonth().toUtc()),
+        TimeRange.lastMonth() ==
+            MonthTimeRange.fromDateTime(Moment.startOfLastMonth().toUtc()),
         false,
       );
       expect(
@@ -91,8 +89,8 @@ void main() {
         false,
       );
       expect(
-        TimeRange.prevYear() ==
-            YearTimeRange.fromDateTime(Moment.startOfPrevYear().toUtc()),
+        TimeRange.lastYear() ==
+            YearTimeRange.fromDateTime(Moment.startOfLastYear().toUtc()),
         false,
       );
     });
@@ -100,7 +98,8 @@ void main() {
       final DateTime now = Moment.startOfToday();
 
       final TimeRange today = TimeRange.today();
-      final CustomTimeRange todayCustom = CustomTimeRange(now, now.endOfDay());
+      final CustomTimeRange todayCustom =
+          CustomTimeRange(now, now.startOfNextDay());
 
       expect(today == todayCustom, false);
       expect(today.from == todayCustom.from, true);
@@ -108,7 +107,7 @@ void main() {
 
       final TimeRange thisMonth = TimeRange.thisMonth();
       final CustomTimeRange thisMonthCustom =
-          CustomTimeRange(now.startOfMonth(), now.endOfMonth());
+          CustomTimeRange(now.startOfMonth(), now.startOfNextMonth());
 
       expect(thisMonth == thisMonthCustom, false);
       expect(thisMonth.from == thisMonthCustom.from, true);
@@ -116,7 +115,7 @@ void main() {
 
       final TimeRange thisYear = TimeRange.thisYear();
       final CustomTimeRange thisYearCustom =
-          CustomTimeRange(now.startOfYear(), now.endOfYear());
+          CustomTimeRange(now.startOfYear(), now.startOfNextYear());
 
       expect(thisYear == thisYearCustom, false);
       expect(thisYear.from == thisYearCustom.from, true);
@@ -127,18 +126,15 @@ void main() {
   group("Duration", () {
     test("Day", () {
       final TimeRange today = TimeRange.today();
-      expect(today.duration, Duration(days: 1) - aMicrosecond);
+      expect(today.duration, Duration(days: 1));
     });
 
     test("Month days", () {
       for (final year in [1970, 2000, 2020, 2021, 2024]) {
         for (final month in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]) {
           final MonthTimeRange monthRange = MonthTimeRange(year, month);
-          expect(
-            monthRange.duration,
-            Duration(days: DateTime(year, month).endOfMonth().day) -
-                aMicrosecond,
-          );
+          expect(monthRange.duration,
+              Duration(days: DateTime(year, month).endOfMonth().day));
         }
       }
     });
@@ -148,7 +144,7 @@ void main() {
         final YearTimeRange yearRange = YearTimeRange(year);
         expect(
           yearRange.duration,
-          Duration(days: DateTime(year).endOfYear().dayOfYear) - aMicrosecond,
+          Duration(days: DateTime(year).endOfYear().dayOfYear),
         );
       }
     });
@@ -182,8 +178,8 @@ void main() {
     // we can't do `month.from.toUtc()`
     expect(monthRange.toUtc().isUtc, true);
     expect(monthRange.toUtc().from, DateTime.utc(now.year, now.month));
-    expect(
-        monthRange.toUtc().to, DateTime.utc(now.year, now.month).endOfMonth());
+    expect(monthRange.toUtc().to,
+        DateTime.utc(now.year, now.month).startOfNextMonth());
   });
 
   test("YearTimeRange", () {
@@ -194,7 +190,7 @@ void main() {
     // we can't do `year.from.toUtc()`
     expect(yearRange.toUtc().isUtc, true);
     expect(yearRange.toUtc().from, DateTime.utc(now.year));
-    expect(yearRange.toUtc().to, DateTime.utc(now.year).endOfYear());
+    expect(yearRange.toUtc().to, DateTime.utc(now.year).startOfNextYear());
   });
 
   test("CustomTimeRange", () {
@@ -247,5 +243,29 @@ void main() {
       expect(customRange.contains(customRange.from - aMicrosecond), false);
       expect(customRange.contains(customRange.to + aMicrosecond), false);
     });
+  });
+
+  test("next/prev time ranges", () {
+    final HourTimeRange thisHour = TimeRange.thisHour();
+    final HourTimeRange nextHour = TimeRange.nextHour();
+    final HourTimeRange lastHour = TimeRange.lastHour();
+    final DayTimeRange today = TimeRange.today();
+    final DayTimeRange tomorrow = TimeRange.tomorrow();
+    final DayTimeRange yesterday = TimeRange.yesterday();
+    final MonthTimeRange thisMonth = TimeRange.thisMonth();
+    final MonthTimeRange nextMonth = TimeRange.nextMonth();
+    final MonthTimeRange lastMonth = TimeRange.lastMonth();
+    final YearTimeRange thisYear = TimeRange.thisYear();
+    final YearTimeRange nextYear = TimeRange.nextYear();
+    final YearTimeRange lastYear = TimeRange.lastYear();
+
+    expect(thisHour.next, nextHour);
+    expect(thisHour.last, lastHour);
+    expect(today.next, tomorrow);
+    expect(today.last, yesterday);
+    expect(thisMonth.next, nextMonth);
+    expect(thisMonth.last, lastMonth);
+    expect(thisYear.next, nextYear);
+    expect(thisYear.last, lastYear);
   });
 }


### PR DESCRIPTION
- TimeRange
  - **[BREAKING]** Renamed all variable/methods with "prev" to "last"
  - Added `HourTimeRange`, `LocalWeekTimeRange` and `IsoWeekTimeRange`
  - **[BREAKING]** TimeRange's `to` is now exclusive. This means
    `DayTimeRange().duration` will equal to `Duration(days:1)` unless there's a
    [daylight saving](https://en.wikipedia.org/wiki/Daylight_saving_time#Effects_on_social_relations)
     going on.
  - Added next/last getters on some TimeRange classes.
- **[BREAKING]** Removes deprecated formatter tokens `YYYYYY` and `Y`
- `Moment.` relative constructors
  - **[BREAKING]** Renamed all variable/methods with "prev" to "last"
  - Added `Moment.startOfThisLocalWeek()`, with `endOf` and `next`/`prev` variants
  - Added `Moment.startOfThisIsoWeek()`, with `endOf` and `next`/`prev` variants
  - Added `Moment.startOfThisHour()`, with `endOf` and `next`/`prev` variants
- Added relative finder methods such as `.startOfNextDay()`.
- Added `.startOfIsoWeek()` and `.endOfIsoWeek()`
- Exposes `DateTimeConstructors` (no longer need to import)