### PR TITLE
feat: add Polish (pl_PL) locale support

### DIFF
--- a/lib/src/localizations/all.dart
+++ b/lib/src/localizations/all.dart
@@ -42,6 +42,9 @@ export 'pt_PT.dart';
 import 'zh_CN.dart';
 export 'zh_CN.dart';
 
+import 'pl_PL.dart';
+export 'pl_PL.dart';
+
 typedef LocalizationFn = MomentLocalization Function();
 
 abstract class MomentLocalizations {
@@ -63,6 +66,7 @@ abstract class MomentLocalizations {
     "ru_RU": () => LocalizationRuRu(),
     "it_IT": () => LocalizationItIt(),
     "zh_CN": () => LocalizationZhCn(),
+    "pl_PL": () => LocalizationPlPl(),
   };
 
   /// Retreives locale
@@ -192,4 +196,7 @@ abstract class MomentLocalizations {
 
   /// Simplified Chinese (China)
   static LocalizationZhCn zhCn() => LocalizationZhCn();
+
+  /// Polish (Poland)
+  static LocalizationPlPl pl() => LocalizationPlPl();
 }

--- a/lib/src/localizations/mixins/pl_PL/duration.dart
+++ b/lib/src/localizations/mixins/pl_PL/duration.dart
@@ -1,0 +1,76 @@
+import 'package:moment_dart/moment_dart.dart';
+import 'package:moment_dart/src/localizations/mixins/pl_PL/units.dart';
+
+mixin PlPlDuration on PlPlUnits {
+  /// If overriden, must implement for all [Abbreviation]s
+  Map<Abbreviation, String> get durationDelimiter => {
+        Abbreviation.none: " i ",
+        Abbreviation.semi: " ",
+        Abbreviation.full: " ",
+      };
+
+  @override
+  String duration(
+    Duration duration, {
+    bool round = true,
+    bool omitZeros = true,
+    bool includeWeeks = false,
+    Abbreviation form = Abbreviation.none,
+    String? delimiter,
+    DurationFormat format = DurationFormat.auto,
+    bool dropPrefixOrSuffix = false,
+  }) {
+    final bool past = duration.isNegative;
+
+    Duration left = duration.abs();
+
+    if (format.isAuto) {
+      format = DurationFormat.resolveAuto(duration, includeWeeks);
+    }
+
+    final List<String> result = [];
+
+    for (int i = 0; i < format.length; i++) {
+      final bool last = i == format.length - 1;
+
+      final DurationUnit unit = format.units[i];
+
+      final int unitValue = last
+          ? (_roundOrTruncate(left.inMicroseconds / unit.microseconds, round))
+          : (left.inMicroseconds ~/ unit.microseconds);
+
+      final DurationInterval interval =
+          DurationInterval.findByUnit(unitValue, unit);
+
+      final String unitString =
+          units[interval]?.get(form, dropPrefixOrSuffix, unitValue) ??
+              "¯\\_(ツ)_/¯";
+
+      if (!(omitZeros && unitValue == 0)) {
+        result.add(unitString.replaceAll(srDelta, unitValue.toString()));
+      }
+
+      left -= Duration(microseconds: unit.microseconds * unitValue);
+    }
+
+    late final String value;
+
+    if (result.isEmpty) {
+      final String unitString = units[DurationInterval.lessThanASecond]
+              ?.get(form, dropPrefixOrSuffix) ??
+          "¯\\_(ツ)_/¯";
+
+      value = unitString;
+    } else {
+      value = result.join(delimiter ?? durationDelimiter[form]!);
+    }
+
+    if (dropPrefixOrSuffix) return value;
+
+    return past ? relativePast(value) : relativeFuture(value);
+  }
+
+  int _roundOrTruncate(num x, bool round) {
+    return round ? x.round() : x.toInt();
+  }
+}

--- a/lib/src/localizations/mixins/pl_PL/relative.dart
+++ b/lib/src/localizations/mixins/pl_PL/relative.dart
@@ -1,0 +1,32 @@
+import 'package:moment_dart/moment_dart.dart';
+import 'package:moment_dart/src/localizations/mixins/pl_PL/units.dart';
+
+mixin PlPlRelative on PlPlUnits {
+  @override
+  String relative(
+    Duration duration, {
+    bool dropPrefixOrSuffix = false,
+    Abbreviation form = Abbreviation.none,
+  }) {
+    final bool past = duration.isNegative;
+
+    duration = duration.abs();
+
+    DurationInterval interval = MomentLocalization.relativeThreshold(duration);
+
+    String value = (units[interval]?.get(form, dropPrefixOrSuffix,
+            DurationUnit.relativeDuration(duration, interval.unit)) ??
+        "¯\\_(ツ)_/¯");
+
+    if (!interval.singular) {
+      value = value.replaceAll(
+        srDelta,
+        DurationUnit.relativeDuration(duration, interval.unit).toString(),
+      );
+    }
+
+    if (dropPrefixOrSuffix) return value;
+
+    return past ? relativePast(value) : relativeFuture(value);
+  }
+}

--- a/lib/src/localizations/mixins/pl_PL/unit_string.dart
+++ b/lib/src/localizations/mixins/pl_PL/unit_string.dart
@@ -1,0 +1,60 @@
+import 'package:moment_dart/moment_dart.dart';
+import 'package:moment_dart/src/localizations/mixins/pl_PL/units.dart';
+
+class PolishSingularUnitString extends CountDependentUnitString {
+  final String mianownik;
+  final String biernik;
+  final String short;
+
+  const PolishSingularUnitString(
+    this.mianownik,
+    this.biernik,
+    this.short,
+  );
+
+  @override
+  String get(Abbreviation form, bool dropPrefixOrSuffix, [int count = 1]) {
+    if (form != Abbreviation.none) {
+      return short;
+    }
+
+    if (dropPrefixOrSuffix) {
+      return mianownik;
+    }
+
+    return biernik;
+  }
+}
+
+class PolishPluralUnitString extends CountDependentUnitString {
+  final String singular;
+  final String few;
+  final String many;
+  final String short;
+
+  const PolishPluralUnitString({
+    required this.singular,
+    required this.few,
+    required this.many,
+    required this.short,
+  });
+
+  @override
+  String get(Abbreviation form, bool dropPrefixOrSuffix, [int count = 1]) {
+    if (form != Abbreviation.none) {
+      return short;
+    }
+    // Rules for Polish pluralization (same as Russian/Slavic):
+    // 1. If number ends with 1 but not 11: singular
+    // 2. If number ends with 2-4 but not 12-14: few
+    // 3. Otherwise: many
+    if ((count % 10) == 1 && (count % 100) != 11) {
+      return singular;
+    } else if ([2, 3, 4].contains(count % 10) &&
+        ![12, 13, 14].contains(count % 100)) {
+      return few;
+    } else {
+      return many;
+    }
+  }
+}

--- a/lib/src/localizations/mixins/pl_PL/units.dart
+++ b/lib/src/localizations/mixins/pl_PL/units.dart
@@ -1,0 +1,108 @@
+import 'package:moment_dart/moment_dart.dart';
+import 'package:moment_dart/src/localizations/mixins/pl_PL/unit_string.dart';
+import 'package:moment_dart/src/localizations/mixins/simple_units.dart';
+
+abstract class CountDependentUnitString extends UnitString {
+  const CountDependentUnitString();
+
+  @override
+  String get(Abbreviation form, bool dropPrefixOrSuffix, [int count = 1]);
+}
+
+mixin PlPlUnits on SimpleUnits {
+  @override
+  String relativePast(String unit) {
+    return "$unit temu";
+  }
+
+  @override
+  String relativeFuture(String unit) {
+    return "za $unit";
+  }
+
+  @override
+  Map<DurationInterval, CountDependentUnitString> get units => {
+        DurationInterval.lessThanASecond: PolishSingularUnitString(
+          "kilka sekund",
+          "kilka sekund",
+          "kilka sek.",
+        ),
+        DurationInterval.aSecond: PolishSingularUnitString(
+          "sekunda",
+          "sekundę",
+          "sek.",
+        ),
+        DurationInterval.seconds: PolishPluralUnitString(
+          singular: "$srDelta sekunda",
+          few: "$srDelta sekundy",
+          many: "$srDelta sekund",
+          short: "$srDelta sek.",
+        ),
+        DurationInterval.aMinute: PolishSingularUnitString(
+          "1 minuta",
+          "minutę",
+          "min",
+        ),
+        DurationInterval.minutes: PolishPluralUnitString(
+          singular: "$srDelta minuta",
+          few: "$srDelta minuty",
+          many: "$srDelta minut",
+          short: "$srDelta min",
+        ),
+        DurationInterval.anHour: PolishSingularUnitString(
+          "godzina",
+          "godzinę",
+          "godz.",
+        ),
+        DurationInterval.hours: PolishPluralUnitString(
+          singular: "$srDelta godzina",
+          few: "$srDelta godziny",
+          many: "$srDelta godzin",
+          short: "$srDelta godz.",
+        ),
+        DurationInterval.aDay: PolishSingularUnitString(
+          "dzień",
+          "dzień",
+          "dz.",
+        ),
+        DurationInterval.days: PolishPluralUnitString(
+          singular: "$srDelta dzień",
+          few: "$srDelta dni",
+          many: "$srDelta dni",
+          short: "$srDelta dn.",
+        ),
+        DurationInterval.aWeek: PolishSingularUnitString(
+          "1 tydzień",
+          "tydzień",
+          "1 tydz.",
+        ),
+        DurationInterval.weeks: PolishPluralUnitString(
+          singular: "$srDelta tydzień",
+          few: "$srDelta tygodnie",
+          many: "$srDelta tygodni",
+          short: "$srDelta tyg.",
+        ),
+        DurationInterval.aMonth: PolishSingularUnitString(
+          "miesiąc",
+          "miesiąc",
+          "1 mies.",
+        ),
+        DurationInterval.months: PolishPluralUnitString(
+          singular: "$srDelta miesiąc",
+          few: "$srDelta miesiące",
+          many: "$srDelta miesięcy",
+          short: "$srDelta mies.",
+        ),
+        DurationInterval.aYear: PolishSingularUnitString(
+          "rok",
+          "rok",
+          "1 r.",
+        ),
+        DurationInterval.years: PolishPluralUnitString(
+          singular: "$srDelta rok",
+          few: "$srDelta lata",
+          many: "$srDelta lat",
+          short: "$srDelta l.",
+        ),
+      };
+}

--- a/lib/src/localizations/pl_PL.dart
+++ b/lib/src/localizations/pl_PL.dart
@@ -1,0 +1,232 @@
+// ignore_for_file: file_names
+
+import 'package:moment_dart/moment_dart.dart';
+import 'package:moment_dart/src/localizations/mixins/month_names.dart';
+import 'package:moment_dart/src/localizations/mixins/ordinal_numbers.dart';
+import 'package:moment_dart/src/localizations/mixins/pl_PL/duration.dart';
+import 'package:moment_dart/src/localizations/mixins/pl_PL/relative.dart';
+import 'package:moment_dart/src/localizations/mixins/pl_PL/units.dart';
+import 'package:moment_dart/src/localizations/mixins/simple_range.dart';
+import 'package:moment_dart/src/localizations/mixins/simple_units.dart';
+import 'package:moment_dart/src/localizations/mixins/weekday_shortforms.dart';
+import 'package:moment_dart/src/types.dart';
+
+/// Language: Polish (Poland)
+/// Country: Poland
+class LocalizationPlPl extends MomentLocalization
+    with
+        MonthNames,
+        Ordinal,
+        SimpleUnits,
+        PlPlUnits,
+        PlPlRelative,
+        PlPlDuration,
+        SimpleRange,
+        WeekdayShortForms {
+  static LocalizationPlPl? _instance;
+
+  LocalizationPlPl._internal() : super();
+
+  factory LocalizationPlPl() {
+    _instance ??= LocalizationPlPl._internal();
+    return _instance!;
+  }
+
+  @override
+  String get endonym => "Polski";
+
+  @override
+  String get languageCode => "pl";
+
+  @override
+  String get countryCode => "PL";
+
+  @override
+  String get languageNameInEnglish => "Polish (Poland)";
+
+  @override
+  Map<int, String> get monthNames => {
+        1: "Styczeń",
+        2: "Luty",
+        3: "Marzec",
+        4: "Kwiecień",
+        5: "Maj",
+        6: "Czerwiec",
+        7: "Lipiec",
+        8: "Sierpień",
+        9: "Wrzesień",
+        10: "Październik",
+        11: "Listopad",
+        12: "Grudzień",
+      };
+
+  /// Genitive forms used in date expressions like "5 marca"
+  static const Map<int, String> _monthNamesGenitive = {
+    1: "stycznia",
+    2: "lutego",
+    3: "marca",
+    4: "kwietnia",
+    5: "maja",
+    6: "czerwca",
+    7: "lipca",
+    8: "sierpnia",
+    9: "września",
+    10: "października",
+    11: "listopada",
+    12: "grudnia",
+  };
+
+  @override
+  Map<int, String> get monthNamesShort => {
+        1: "Sty",
+        2: "Lut",
+        3: "Mar",
+        4: "Kwi",
+        5: "Maj",
+        6: "Cze",
+        7: "Lip",
+        8: "Sie",
+        9: "Wrz",
+        10: "Paź",
+        11: "Lis",
+        12: "Gru",
+      };
+
+  @override
+  Map<int, String> get weekdayName => {
+        DateTime.monday: "Poniedziałek",
+        DateTime.tuesday: "Wtorek",
+        DateTime.wednesday: "Środa",
+        DateTime.thursday: "Czwartek",
+        DateTime.friday: "Piątek",
+        DateTime.saturday: "Sobota",
+        DateTime.sunday: "Niedziela",
+      };
+
+  @override
+  Map<int, String> get weekdayNameShort => {
+        DateTime.monday: "Pon",
+        DateTime.tuesday: "Wt",
+        DateTime.wednesday: "Śr",
+        DateTime.thursday: "Czw",
+        DateTime.friday: "Pt",
+        DateTime.saturday: "Sob",
+        DateTime.sunday: "Ndz",
+      };
+
+  @override
+  Map<int, String> get weekdayNameMin => {
+        DateTime.monday: "Pn",
+        DateTime.tuesday: "Wt",
+        DateTime.wednesday: "Śr",
+        DateTime.thursday: "Cz",
+        DateTime.friday: "Pt",
+        DateTime.saturday: "So",
+        DateTime.sunday: "Nd",
+      };
+
+  @override
+  FormatSetOptional overrideFormatters() {
+    return {
+      // From [Ordinal] mixin
+      ...formattersWithOrdinal,
+      // From [MonthNames] mixin
+      ...formattersForMonthNames,
+      // From [WeekdayShortForms] mixin
+      ...formattersForWeekdayShortForms,
+      // Localization aware formats
+      FormatterToken.L: (dateTime) => reformat(dateTime, "DD.MM.YYYY"),
+      FormatterToken.l: (dateTime) => reformat(dateTime, "D.M.YYYY"),
+      FormatterToken.LL: (dateTime) =>
+          "${dateTime.day} ${_monthNamesGenitive[dateTime.month]} ${dateTime.year}",
+      FormatterToken.ll: (dateTime) =>
+          "${dateTime.day} ${monthNamesShort[dateTime.month]} ${dateTime.year}",
+      FormatterToken.LLL: (dateTime) =>
+          "${dateTime.day} ${_monthNamesGenitive[dateTime.month]} ${dateTime.year} ${reformat(dateTime, "HH:mm")}",
+      FormatterToken.lll: (dateTime) =>
+          "${dateTime.day} ${monthNamesShort[dateTime.month]} ${dateTime.year} ${reformat(dateTime, "H:mm")}",
+      FormatterToken.LLLL: (dateTime) =>
+          "${weekdayName[dateTime.weekday]}, ${dateTime.day} ${_monthNamesGenitive[dateTime.month]} ${dateTime.year} ${reformat(dateTime, "HH:mm")}",
+      FormatterToken.llll: (dateTime) =>
+          "${weekdayNameShort[dateTime.weekday]}, ${dateTime.day} ${monthNamesShort[dateTime.month]} ${dateTime.year} ${reformat(dateTime, "H:mm")}",
+      FormatterToken.LT: (dateTime) => reformat(dateTime, "HH:mm"),
+      FormatterToken.LTS: (dateTime) => reformat(dateTime, "HH:mm:ss"),
+    };
+  }
+
+  @override
+  String ordinalNumber(int n) {
+    return "$n.";
+  }
+
+  @override
+  CalenderLocalizationData get calendarData => calenderLocalizationDataPlPl;
+
+  /// Returns "Ostatni/Ostatnia/Ostatnie" based on grammatical gender
+  /// of the Polish weekday name.
+  ///
+  /// Masculine: Poniedziałek, Wtorek, Czwartek, Piątek
+  /// Feminine: Środa, Sobota
+  /// Neuter: (none in standard weekdays, but Niedziela is feminine)
+  static String last(String weekday) {
+    switch (weekday) {
+      case "Środa":
+      case "Sobota":
+      case "Niedziela":
+        return "Ostatnia ${weekday.toLowerCase()}";
+      default:
+        // Poniedziałek, Wtorek, Czwartek, Piątek
+        return "Ostatni ${weekday.toLowerCase()}";
+    }
+  }
+
+  static String at(String date, String time) => "$date o $time";
+
+  static const CalenderLocalizationData calenderLocalizationDataPlPl =
+      CalenderLocalizationData(
+    relativeDayNames: {
+      -2: "Przedwczoraj",
+      -1: "Wczoraj",
+      0: "Dzisiaj",
+      1: "Jutro",
+      2: "Pojutrze",
+    },
+    keywords: CalenderLocalizationKeywords(
+      at: at,
+      lastWeekday: last,
+    ),
+  );
+
+  @override
+  int get weekStart => DateTime.monday;
+
+  @override
+  SimpleRangeData get simpleRangeData => SimpleRangeData(
+        thisWeek: "Ten tydzień",
+        year: (range, {anchor, useRelative = true}) {
+          anchor ??= Moment.now();
+
+          if (useRelative && range.year == anchor.year) {
+            return "W tym roku";
+          }
+
+          return "${range.year} rok";
+        },
+        month: (range, {anchor, useRelative = true}) {
+          anchor ??= Moment.now();
+
+          if (useRelative && anchor.year == range.year) {
+            if (anchor.month == range.month) {
+              return "W tym miesiącu";
+            }
+
+            return monthNames[range.month]!;
+          }
+
+          return "${monthNames[range.month]!} ${range.year}";
+        },
+        allAfter: (formattedDate) => "Po $formattedDate",
+        allBefore: (formattedDate) => "Przed $formattedDate",
+        customRangeAllTime: "Cały czas",
+      );
+}

--- a/test/localizations/calendar_test.dart
+++ b/test/localizations/calendar_test.dart
@@ -468,4 +468,44 @@ void main() {
     expect(epoch.calendar(reference: today, omitHours: true), epoch.format());
     expect(epoch.format("LLLL"), "Четверг, 1 Январь 1970 00:00");
   });
+
+  test("pl_PL localization calendar test", () {
+    Moment.setGlobalLocalization(MomentLocalizations.pl());
+
+    // A
+    expect(today.calendar(reference: today), "Dzisiaj o 05:33");
+    expect(tomorrow.calendar(reference: today), "Jutro o 05:33");
+    expect(tueOrDayAfterTomorrow.calendar(reference: today),
+        "Pojutrze o 05:33");
+    expect(yesterday.calendar(reference: today), "Wczoraj o 05:33");
+    expect(
+      fridayOrDayBeforeYesterday.calendar(reference: today),
+      "Przedwczoraj o 05:33",
+    );
+    // B
+    expect(
+      lastMonday.calendar(reference: today, omitHours: true),
+      "Ostatni poniedziałek",
+    );
+    expect(
+      lastTuesday.calendar(reference: today, omitHours: true),
+      "Ostatni wtorek",
+    );
+    expect(
+      lastWednesday.calendar(reference: today, omitHours: true),
+      "Ostatnia środa",
+    );
+    expect(
+      nextWednesday.calendar(reference: today, omitHours: true),
+      "Środa",
+    );
+    expect(
+      nextThursday.calendar(reference: today, omitHours: true),
+      "Czwartek",
+    );
+    expect(nextFriday.calendar(reference: today, omitHours: true), "Piątek");
+    // C
+    expect(epoch.calendar(reference: today, omitHours: true), epoch.format());
+    expect(epoch.format("LLLL"), "Czwartek, 1 stycznia 1970 00:00");
+  });
 }

--- a/test/localizations/duration_test.dart
+++ b/test/localizations/duration_test.dart
@@ -3943,4 +3943,481 @@ void main() {
       'неск. сек',
     );
   });
+
+  test('pl_PL (with suffix) localization duration test', () {
+    final MomentLocalization l10n = LocalizationPlPl();
+
+    expect(
+      l10n.duration(_1y_2mo, form: Abbreviation.none),
+      'za rok i 2 miesiące',
+    );
+    expect(
+      l10n.duration(_1y_2mo, form: Abbreviation.semi),
+      'za 1 r. 2 mies.',
+    );
+
+    expect(
+      l10n.duration(_3y, form: Abbreviation.none),
+      'za 3 lata',
+    );
+    expect(
+      l10n.duration(_3y, form: Abbreviation.full),
+      'za 3 l.',
+    );
+
+    expect(
+      l10n.duration(_3mo_17d, form: Abbreviation.none),
+      'za 3 miesiące i 17 dni',
+    );
+    expect(
+      l10n.duration(_3mo_17d, form: Abbreviation.semi),
+      'za 3 mies. 17 dn.',
+    );
+    expect(
+      l10n.duration(_3mo_17d, form: Abbreviation.full),
+      'za 3 mies. 17 dn.',
+    );
+
+    expect(
+      l10n.duration(_4mo, form: Abbreviation.none),
+      'za 4 miesiące',
+    );
+    expect(
+      l10n.duration(_4mo, form: Abbreviation.semi),
+      'za 4 mies.',
+    );
+    expect(
+      l10n.duration(_4mo, form: Abbreviation.full),
+      'za 4 mies.',
+    );
+
+    expect(
+      l10n.duration(
+        _3w_2d_or_23d,
+        includeWeeks: true,
+        form: Abbreviation.none,
+      ),
+      'za 3 tygodnie i 2 dni',
+    );
+    expect(
+      l10n.duration(
+        _3w_2d_or_23d,
+        includeWeeks: true,
+        form: Abbreviation.semi,
+      ),
+      'za 3 tyg. 2 dn.',
+    );
+    expect(
+      l10n.duration(
+        _3w_2d_or_23d,
+        includeWeeks: true,
+        form: Abbreviation.full,
+      ),
+      'za 3 tyg. 2 dn.',
+    );
+    // Without includeWeeks
+    expect(
+      l10n.duration(_3w_2d_or_23d, form: Abbreviation.none),
+      'za 23 dni',
+    );
+    expect(
+      l10n.duration(_3w_2d_or_23d, form: Abbreviation.semi),
+      'za 23 dn.',
+    );
+    expect(
+      l10n.duration(_3w_2d_or_23d, form: Abbreviation.full),
+      'za 23 dn.',
+    );
+
+    expect(
+      l10n.duration(
+        _4w_or_28d,
+        includeWeeks: true,
+        form: Abbreviation.none,
+      ),
+      'za 4 tygodnie',
+    );
+    expect(
+      l10n.duration(
+        _4w_or_28d,
+        includeWeeks: true,
+        form: Abbreviation.semi,
+      ),
+      'za 4 tyg.',
+    );
+    expect(
+      l10n.duration(
+        _4w_or_28d,
+        includeWeeks: true,
+        form: Abbreviation.full,
+      ),
+      'za 4 tyg.',
+    );
+    // Without includeWeeks
+    expect(
+      l10n.duration(_4w_or_28d, form: Abbreviation.none),
+      'za 28 dni',
+    );
+    expect(
+      l10n.duration(_4w_or_28d, form: Abbreviation.semi),
+      'za 28 dn.',
+    );
+    expect(
+      l10n.duration(_4w_or_28d, form: Abbreviation.full),
+      'za 28 dn.',
+    );
+
+    expect(
+      l10n.duration(_6d_7h, form: Abbreviation.none),
+      'za 6 dni i 7 godzin',
+    );
+    expect(
+      l10n.duration(_6d_7h, form: Abbreviation.semi),
+      'za 6 dn. 7 godz.',
+    );
+    expect(
+      l10n.duration(_6d_7h, form: Abbreviation.full),
+      'za 6 dn. 7 godz.',
+    );
+
+    expect(
+      l10n.duration(_6d, form: Abbreviation.none),
+      'za 6 dni',
+    );
+    expect(
+      l10n.duration(_6d, form: Abbreviation.semi),
+      'za 6 dn.',
+    );
+    expect(
+      l10n.duration(_6d, form: Abbreviation.full),
+      'za 6 dn.',
+    );
+
+    expect(
+      l10n.duration(_8h_8m, form: Abbreviation.none),
+      'za 8 godzin i 8 minut',
+    );
+    expect(
+      l10n.duration(_8h_8m, form: Abbreviation.semi),
+      'za 8 godz. 8 min',
+    );
+    expect(
+      l10n.duration(_8h_8m, form: Abbreviation.full),
+      'za 8 godz. 8 min',
+    );
+
+    expect(
+      l10n.duration(_8h, form: Abbreviation.none),
+      'za 8 godzin',
+    );
+    expect(
+      l10n.duration(_8h, form: Abbreviation.semi),
+      'za 8 godz.',
+    );
+    expect(
+      l10n.duration(_8h, form: Abbreviation.full),
+      'za 8 godz.',
+    );
+
+    expect(
+      l10n.duration(_48m_42s, form: Abbreviation.none),
+      'za 48 minut i 42 sekundy',
+    );
+    expect(
+      l10n.duration(_48m_42s, form: Abbreviation.semi),
+      'za 48 min 42 sek.',
+    );
+    expect(
+      l10n.duration(_48m_42s, form: Abbreviation.full),
+      'za 48 min 42 sek.',
+    );
+
+    expect(
+      l10n.duration(_35m, form: Abbreviation.none),
+      'za 35 minut',
+    );
+    expect(
+      l10n.duration(_35m, form: Abbreviation.semi),
+      'za 35 min',
+    );
+    expect(
+      l10n.duration(_35m, form: Abbreviation.full),
+      'za 35 min',
+    );
+
+    expect(
+      l10n.duration(_42s, form: Abbreviation.none),
+      'za 42 sekundy',
+    );
+    expect(
+      l10n.duration(_42s, form: Abbreviation.semi),
+      'za 42 sek.',
+    );
+    expect(
+      l10n.duration(_42s, form: Abbreviation.full),
+      'za 42 sek.',
+    );
+
+    expect(
+      l10n.duration(_zero, form: Abbreviation.none),
+      'za kilka sekund',
+    );
+    expect(
+      l10n.duration(_zero, form: Abbreviation.semi),
+      'za kilka sek.',
+    );
+    expect(
+      l10n.duration(_zero, form: Abbreviation.full),
+      'za kilka sek.',
+    );
+  });
+
+  test('pl_PL (standalone) localization duration test', () {
+    final MomentLocalization l10n = LocalizationPlPl();
+
+    expect(
+      l10n.duration(_1y_2mo, dropPrefixOrSuffix: true, form: Abbreviation.none),
+      'rok i 2 miesiące',
+    );
+
+    expect(
+      l10n.duration(_1y_2mo, dropPrefixOrSuffix: true, form: Abbreviation.full),
+      '1 r. 2 mies.',
+    );
+
+    expect(
+      l10n.duration(_3y, dropPrefixOrSuffix: true, form: Abbreviation.none),
+      '3 lata',
+    );
+    expect(
+      l10n.duration(_3y, dropPrefixOrSuffix: true, form: Abbreviation.semi),
+      '3 l.',
+    );
+    expect(
+      l10n.duration(_3y, dropPrefixOrSuffix: true, form: Abbreviation.full),
+      '3 l.',
+    );
+
+    expect(
+      l10n.duration(_3mo_17d,
+          dropPrefixOrSuffix: true, form: Abbreviation.none),
+      '3 miesiące i 17 dni',
+    );
+    expect(
+      l10n.duration(_3mo_17d,
+          dropPrefixOrSuffix: true, form: Abbreviation.semi),
+      '3 mies. 17 dn.',
+    );
+    expect(
+      l10n.duration(_3mo_17d,
+          dropPrefixOrSuffix: true, form: Abbreviation.full),
+      '3 mies. 17 dn.',
+    );
+
+    expect(
+      l10n.duration(_4mo, dropPrefixOrSuffix: true, form: Abbreviation.none),
+      '4 miesiące',
+    );
+    expect(
+      l10n.duration(_4mo, dropPrefixOrSuffix: true, form: Abbreviation.semi),
+      '4 mies.',
+    );
+    expect(
+      l10n.duration(_4mo, dropPrefixOrSuffix: true, form: Abbreviation.full),
+      '4 mies.',
+    );
+
+    expect(
+      l10n.duration(
+        _3w_2d_or_23d,
+        dropPrefixOrSuffix: true,
+        includeWeeks: true,
+        form: Abbreviation.none,
+      ),
+      '3 tygodnie i 2 dni',
+    );
+    expect(
+      l10n.duration(
+        _3w_2d_or_23d,
+        dropPrefixOrSuffix: true,
+        includeWeeks: true,
+        form: Abbreviation.semi,
+      ),
+      '3 tyg. 2 dn.',
+    );
+    expect(
+      l10n.duration(
+        _3w_2d_or_23d,
+        dropPrefixOrSuffix: true,
+        includeWeeks: true,
+        form: Abbreviation.full,
+      ),
+      '3 tyg. 2 dn.',
+    );
+    expect(
+      l10n.duration(_3w_2d_or_23d,
+          dropPrefixOrSuffix: true, form: Abbreviation.none),
+      '23 dni',
+    );
+    expect(
+      l10n.duration(_3w_2d_or_23d,
+          dropPrefixOrSuffix: true, form: Abbreviation.semi),
+      '23 dn.',
+    );
+    expect(
+      l10n.duration(_3w_2d_or_23d,
+          dropPrefixOrSuffix: true, form: Abbreviation.full),
+      '23 dn.',
+    );
+
+    expect(
+      l10n.duration(
+        _4w_or_28d,
+        dropPrefixOrSuffix: true,
+        includeWeeks: true,
+        form: Abbreviation.none,
+      ),
+      '4 tygodnie',
+    );
+    expect(
+      l10n.duration(
+        _4w_or_28d,
+        dropPrefixOrSuffix: true,
+        includeWeeks: true,
+        form: Abbreviation.semi,
+      ),
+      '4 tyg.',
+    );
+    expect(
+      l10n.duration(
+        _4w_or_28d,
+        dropPrefixOrSuffix: true,
+        includeWeeks: true,
+        form: Abbreviation.full,
+      ),
+      '4 tyg.',
+    );
+    expect(
+      l10n.duration(_4w_or_28d,
+          dropPrefixOrSuffix: true, form: Abbreviation.none),
+      '28 dni',
+    );
+    expect(
+      l10n.duration(_4w_or_28d,
+          dropPrefixOrSuffix: true, form: Abbreviation.semi),
+      '28 dn.',
+    );
+    expect(
+      l10n.duration(_4w_or_28d,
+          dropPrefixOrSuffix: true, form: Abbreviation.full),
+      '28 dn.',
+    );
+
+    expect(
+      l10n.duration(_6d_7h, dropPrefixOrSuffix: true, form: Abbreviation.none),
+      '6 dni i 7 godzin',
+    );
+    expect(
+      l10n.duration(_6d_7h, dropPrefixOrSuffix: true, form: Abbreviation.semi),
+      '6 dn. 7 godz.',
+    );
+    expect(
+      l10n.duration(_6d_7h, dropPrefixOrSuffix: true, form: Abbreviation.full),
+      '6 dn. 7 godz.',
+    );
+
+    expect(
+      l10n.duration(_6d, dropPrefixOrSuffix: true, form: Abbreviation.none),
+      '6 dni',
+    );
+    expect(
+      l10n.duration(_6d, dropPrefixOrSuffix: true, form: Abbreviation.semi),
+      '6 dn.',
+    );
+    expect(
+      l10n.duration(_6d, dropPrefixOrSuffix: true, form: Abbreviation.full),
+      '6 dn.',
+    );
+
+    expect(
+      l10n.duration(_8h_8m, dropPrefixOrSuffix: true, form: Abbreviation.none),
+      '8 godzin i 8 minut',
+    );
+    expect(
+      l10n.duration(_8h_8m, dropPrefixOrSuffix: true, form: Abbreviation.semi),
+      '8 godz. 8 min',
+    );
+    expect(
+      l10n.duration(_8h_8m, dropPrefixOrSuffix: true, form: Abbreviation.full),
+      '8 godz. 8 min',
+    );
+
+    expect(
+      l10n.duration(_8h, dropPrefixOrSuffix: true, form: Abbreviation.none),
+      '8 godzin',
+    );
+    expect(
+      l10n.duration(_8h, dropPrefixOrSuffix: true, form: Abbreviation.semi),
+      '8 godz.',
+    );
+    expect(
+      l10n.duration(_8h, dropPrefixOrSuffix: true, form: Abbreviation.full),
+      '8 godz.',
+    );
+
+    expect(
+      l10n.duration(_48m_42s,
+          dropPrefixOrSuffix: true, form: Abbreviation.none),
+      '48 minut i 42 sekundy',
+    );
+    expect(
+      l10n.duration(_48m_42s,
+          dropPrefixOrSuffix: true, form: Abbreviation.semi),
+      '48 min 42 sek.',
+    );
+    expect(
+      l10n.duration(_48m_42s,
+          dropPrefixOrSuffix: true, form: Abbreviation.full),
+      '48 min 42 sek.',
+    );
+
+    expect(
+      l10n.duration(_35m, dropPrefixOrSuffix: true, form: Abbreviation.none),
+      '35 minut',
+    );
+    expect(
+      l10n.duration(_35m, dropPrefixOrSuffix: true, form: Abbreviation.semi),
+      '35 min',
+    );
+    expect(
+      l10n.duration(_35m, dropPrefixOrSuffix: true, form: Abbreviation.full),
+      '35 min',
+    );
+
+    expect(
+      l10n.duration(_42s, dropPrefixOrSuffix: true, form: Abbreviation.none),
+      '42 sekundy',
+    );
+    expect(
+      l10n.duration(_42s, dropPrefixOrSuffix: true, form: Abbreviation.semi),
+      '42 sek.',
+    );
+    expect(
+      l10n.duration(_42s, dropPrefixOrSuffix: true, form: Abbreviation.full),
+      '42 sek.',
+    );
+
+    expect(
+      l10n.duration(_zero, dropPrefixOrSuffix: true, form: Abbreviation.none),
+      'kilka sekund',
+    );
+    expect(
+      l10n.duration(_zero, dropPrefixOrSuffix: true, form: Abbreviation.semi),
+      'kilka sek.',
+    );
+    expect(
+      l10n.duration(_zero, dropPrefixOrSuffix: true, form: Abbreviation.full),
+      'kilka sek.',
+    );
+  });
 }

--- a/test/localizations/find_by_language_test.dart
+++ b/test/localizations/find_by_language_test.dart
@@ -64,6 +64,10 @@ void main() {
       MomentLocalizations.byLanguage('ru'),
       TypeMatcher<LocalizationRuRu>(),
     );
+    expect(
+      MomentLocalizations.byLanguage('pl'),
+      TypeMatcher<LocalizationPlPl>(),
+    );
   });
 
   test("MomentLocalizations.byLanguage strict test", () {
@@ -269,6 +273,22 @@ void main() {
         strict: true,
       ),
       TypeMatcher<LocalizationRuRu>(),
+    );
+
+    expect(
+      MomentLocalizations.byLanguage(
+        'pl',
+        strict: true,
+      ),
+      TypeMatcher<LocalizationPlPl>(),
+    );
+    expect(
+      MomentLocalizations.byLanguage(
+        'pl',
+        countryCode: 'PL',
+        strict: true,
+      ),
+      TypeMatcher<LocalizationPlPl>(),
     );
   });
 }

--- a/test/localizations/find_by_locale_test.dart
+++ b/test/localizations/find_by_locale_test.dart
@@ -104,5 +104,14 @@ void main() {
       MomentLocalizations.byLocale("ru"),
       TypeMatcher<LocalizationRuRu>(),
     );
+
+    expect(
+      MomentLocalizations.byLocale("pl_PL"),
+      TypeMatcher<LocalizationPlPl>(),
+    );
+    expect(
+      MomentLocalizations.byLocale("pl"),
+      TypeMatcher<LocalizationPlPl>(),
+    );
   });
 }

--- a/test/localizations/lcid_test.dart
+++ b/test/localizations/lcid_test.dart
@@ -18,5 +18,6 @@ void main() {
     expect(LocalizationItIt().locale, "it_IT");
     expect(LocalizationZhCn().locale, "zh_CN");
     expect(LocalizationRuRu().locale, "ru_RU");
+    expect(LocalizationPlPl().locale, "pl_PL");
   });
 }

--- a/test/localizations/range_test.dart
+++ b/test/localizations/range_test.dart
@@ -411,4 +411,32 @@ void main() {
     expect(allBeforeMyBirthday.format(), "До 1.6.2003");
     expect(allTime.format(), "За все время");
   });
+
+  test("pl_PL range test", () {
+    Moment.setGlobalLocalization(MomentLocalizations.pl());
+
+    final thisWeek = TimeRange.thisLocalWeek();
+    final thisWeekISO = TimeRange.thisIsoWeek();
+    final thisMonth = TimeRange.thisMonth();
+    final thisYear = TimeRange.thisYear();
+    final year = YearTimeRange(2021);
+    final month = MonthTimeRange(1205, 3);
+    final allAfterEpoch = CustomTimeRange(Moment.epoch, Moment.maxValue);
+    final allBeforeMyBirthday =
+        CustomTimeRange(Moment.minValue, DateTime(2003, 6, 1));
+    final allTime = TimeRange.allTime();
+
+    expect(thisWeek.format(), "Ten tydzień");
+    expect(
+      thisWeekISO.format(),
+      "${thisWeekISO.from.toMoment().calendar(omitHours: true)} - ${thisWeekISO.to.toMoment().calendar(omitHours: true)}",
+    );
+    expect(thisMonth.format(), "W tym miesiącu");
+    expect(thisYear.format(), "W tym roku");
+    expect(year.format(), "2021 rok");
+    expect(month.format(), "Marzec 1205");
+    expect(allAfterEpoch.format(), "Po 1.1.1970");
+    expect(allBeforeMyBirthday.format(), "Przed 1.6.2003");
+    expect(allTime.format(), "Cały czas");
+  });
 }

--- a/test/localizations/relative_test.dart
+++ b/test/localizations/relative_test.dart
@@ -619,4 +619,53 @@ void main() {
     expect(tenYearsAgo.from(now), "10 лет назад");
     expect(tenYearsAgo.from(now, dropPrefixOrSuffix: true), "10 лет");
   });
+
+  test("pl_PL localization relative time test", () {
+    Moment.setGlobalLocalization(MomentLocalizations.pl());
+
+    expect(fewMomentsAhead.from(now), "za kilka sekund");
+    expect(fewMomentsAgo.from(now), "kilka sekund temu");
+    expect(
+        fewMomentsAgo.from(now, dropPrefixOrSuffix: true), "kilka sekund");
+    expect(aMinuteAhead.from(now), "za minutę");
+    expect(aMinuteAgo.from(now), "minutę temu");
+    expect(aMinuteAgo.from(now, dropPrefixOrSuffix: true), "1 minuta");
+    expect(fiveMinutesAhead.from(now), "za 5 minut");
+    expect(fiveMinutesAgo.from(now), "5 minut temu");
+    expect(fiveMinutesAgo.from(now, dropPrefixOrSuffix: true), "5 minut");
+    expect(anHourAhead.from(now), "za godzinę");
+    expect(anHourAgo.from(now), "godzinę temu");
+    expect(anHourAgo.from(now, dropPrefixOrSuffix: true), "godzina");
+    expect(sixHoursAhead.from(now), "za 6 godzin");
+    expect(sixHoursAgo.from(now), "6 godzin temu");
+    expect(sixHoursAgo.from(now, dropPrefixOrSuffix: true), "6 godzin");
+    expect(aDayAhead.from(now), "za dzień");
+    expect(aDayAgo.from(now), "dzień temu");
+    expect(aDayAgo.from(now, dropPrefixOrSuffix: true), "dzień");
+    expect(twoDaysAhead.from(now), "za 2 dni");
+    expect(twoDaysAgo.from(now), "2 dni temu");
+    expect(twoDaysAgo.from(now, dropPrefixOrSuffix: true), "2 dni");
+    expect(sixDaysAhead.from(now), "za 6 dni");
+    expect(sixDaysAgo.from(now), "6 dni temu");
+    expect(sixDaysAgo.from(now, dropPrefixOrSuffix: true), "6 dni");
+    expect(aMonthAhead.from(now), "za miesiąc");
+    expect(aMonthAgo.from(now), "miesiąc temu");
+    expect(aMonthAgo.from(now, dropPrefixOrSuffix: true), "miesiąc");
+    expect(fourMonthsAhead.from(now), "za 4 miesiące");
+    expect(fourMonthsAgo.from(now), "4 miesiące temu");
+    expect(fourMonthsAgo.from(now, dropPrefixOrSuffix: true), "4 miesiące");
+    expect(tenMonthsAhead.from(now), "za 10 miesięcy");
+    expect(tenMonthsAgo.from(now), "10 miesięcy temu");
+    expect(tenMonthsAgo.from(now, dropPrefixOrSuffix: true), "10 miesięcy");
+    expect(aYearAhead.from(now), "za rok");
+    expect(aYearAgo.from(now), "rok temu");
+    expect(aYearAgo.from(now, dropPrefixOrSuffix: true), "rok");
+    expect(threeYearsAhead.from(now), "za 3 lata");
+    expect(threeYearsAgo.from(now), "3 lata temu");
+    expect(threeYearsAgo.from(now, dropPrefixOrSuffix: true), "3 lata");
+    expect(fiveYearsAgo.from(now), "5 lat temu");
+    expect(fiveYearsAgo.from(now, dropPrefixOrSuffix: true), "5 lat");
+    expect(tenYearsAgo.from(now), "10 lat temu");
+    expect(tenYearsAgo.from(now, dropPrefixOrSuffix: true), "10 lat");
+  });
 }


### PR DESCRIPTION
## Add Polish (Poland) localization

Adds comprehensive Polish locale (`pl_PL`) following the existing architecture (mixins pattern, same as `ru_RU`).

### Features
- Month names in nominative and genitive (for date expressions like "5 marca")
- Weekday names with grammatical gender agreement ("Ostatni poniedziałek" vs "Ostatnia środa")
- Calendar: Dzisiaj, Wczoraj, Jutro, Przedwczoraj, Pojutrze with "o" time preposition
- Date formats (L/LL/LLL/LLLL/LT/LTS) using genitive months
- Slavic pluralization rules (singular/few/many) for all duration units
- Accusative case forms with prefixes ("za minutę", "godzinę temu")
- Duration formatting with abbreviations and " i " delimiter
- Range formatting ("Ten tydzień", "W tym miesiącu", etc.)
- Week starts on Monday

### Files
- 6 source files (508 lines)
- 7 test files modified (631 lines of tests)
- All 169 existing tests pass