### PR TITLE
fix: Polish plural rule - 'one' category only applies to exactly 1

### DIFF
--- a/lib/src/localizations/mixins/pl_PL/unit_string.dart
+++ b/lib/src/localizations/mixins/pl_PL/unit_string.dart
@@ -44,11 +44,11 @@ class PolishPluralUnitString extends CountDependentUnitString {
     if (form != Abbreviation.none) {
       return short;
     }
-    // Rules for Polish pluralization (same as Russian/Slavic):
-    // 1. If number ends with 1 but not 11: singular
+    // Polish pluralization rules (differ from Russian for "one"):
+    // 1. Exactly 1: singular (unlike Russian where 21, 31, etc. are also singular)
     // 2. If number ends with 2-4 but not 12-14: few
     // 3. Otherwise: many
-    if ((count % 10) == 1 && (count % 100) != 11) {
+    if (count == 1) {
       return singular;
     } else if ([2, 3, 4].contains(count % 10) &&
         ![12, 13, 14].contains(count % 100)) {

--- a/test/localizations/duration_test.dart
+++ b/test/localizations/duration_test.dart
@@ -4420,4 +4420,55 @@ void main() {
       'kilka sek.',
     );
   });
+
+  test('pl_PL Polish plural rules for numbers ending in 1', () {
+    final MomentLocalization l10n = LocalizationPlPl();
+
+    // Polish: 21, 31, etc. use "many" form (NOT singular like Russian)
+    // 21 minutes = "21 minut" (many), NOT "21 minuta" (singular)
+    const Duration _21m = Duration(minutes: 21);
+    const Duration _21h = Duration(hours: 21);
+    const Duration _21d = Duration(days: 21);
+    const Duration _21y = Duration(days: 365 * 21 + 5);
+
+    // With suffix
+    expect(
+      l10n.duration(_21m, form: Abbreviation.none),
+      'za 21 minut',
+    );
+    expect(
+      l10n.duration(_21h, form: Abbreviation.none),
+      'za 21 godzin',
+    );
+    expect(
+      l10n.duration(_21d, form: Abbreviation.none),
+      'za 21 dni',
+    );
+    expect(
+      l10n.duration(_21y, form: Abbreviation.none),
+      'za 21 lat',
+    );
+
+    // Standalone
+    expect(
+      l10n.duration(_21m, dropPrefixOrSuffix: true, form: Abbreviation.none),
+      '21 minut',
+    );
+    expect(
+      l10n.duration(_21h, dropPrefixOrSuffix: true, form: Abbreviation.none),
+      '21 godzin',
+    );
+    expect(
+      l10n.duration(_21d, dropPrefixOrSuffix: true, form: Abbreviation.none),
+      '21 dni',
+    );
+
+    // Also verify count=1 still uses singular (regression check)
+    const Duration _1m = Duration(minutes: 1);
+    expect(
+      l10n.duration(_1m, dropPrefixOrSuffix: true, form: Abbreviation.none,
+          format: DurationFormat.ms),
+      '1 minuta',
+    );
+  });
 }

--- a/test/localizations/relative_test.dart
+++ b/test/localizations/relative_test.dart
@@ -33,6 +33,12 @@ void main() {
   var fiveYearsAgo = now - const Duration(days: 365 * 5 + 1);
   var tenYearsAgo = now - const Duration(days: 365 * 10 + 1);
 
+  // Extra fixtures for testing Polish pluralization with numbers ending in 1
+  var twentyOneMinutesAgo = now - const Duration(minutes: 21);
+  var twentyOneHoursAgo = now - const Duration(hours: 21);
+  var twentyOneDaysAgo = now - const Duration(days: 21);
+  var twentyOneYearsAgo = now - const Duration(days: 365 * 21 + 5);
+
   test("de_DE localization relative time test", () {
     Moment.setGlobalLocalization(MomentLocalizations.de());
 
@@ -667,5 +673,16 @@ void main() {
     expect(fiveYearsAgo.from(now, dropPrefixOrSuffix: true), "5 lat");
     expect(tenYearsAgo.from(now), "10 lat temu");
     expect(tenYearsAgo.from(now, dropPrefixOrSuffix: true), "10 lat");
+
+    // Polish plural rule: numbers ending in 1 (except 1 itself) use "many" form,
+    // NOT singular. This differs from Russian where 21, 31, etc. use singular.
+    expect(twentyOneMinutesAgo.from(now), "21 minut temu");
+    expect(twentyOneMinutesAgo.from(now, dropPrefixOrSuffix: true), "21 minut");
+    expect(twentyOneHoursAgo.from(now), "21 godzin temu");
+    expect(twentyOneHoursAgo.from(now, dropPrefixOrSuffix: true), "21 godzin");
+    expect(twentyOneDaysAgo.from(now), "21 dni temu");
+    expect(twentyOneDaysAgo.from(now, dropPrefixOrSuffix: true), "21 dni");
+    expect(twentyOneYearsAgo.from(now), "21 lat temu");
+    expect(twentyOneYearsAgo.from(now, dropPrefixOrSuffix: true), "21 lat");
   });
 }


### PR DESCRIPTION
**Bug**: The Polish locale used Russian plural rules where numbers ending in 1 (21, 31, 41...) were treated as singular. In Polish, only exactly 1 uses singular form.

**Examples of incorrect output (before fix)**:
- `21 minuta` → should be `21 minut`
- `31 dzień` → should be `31 dni`
- `101 rok` → should be `101 lat`

**Root cause**: `(count % 10) == 1 && (count % 100) != 11` (Russian rule) instead of `count == 1` (Polish rule).

**Changes**:
- `unit_string.dart`: Fixed singular check from modulo-10 to exact equality
- `relative_test.dart`: Added tests for 21 minutes/hours/days/years
- `duration_test.dart`: Added Polish plural rule tests with count=21 + regression check for count=1

All 170 tests pass.